### PR TITLE
Pull Request for Issue49: fix the broken continuous request when the data is too large

### DIFF
--- a/source/Connection/AMDSClientTCPSocket.cpp
+++ b/source/Connection/AMDSClientTCPSocket.cpp
@@ -59,8 +59,6 @@ void AMDSClientTCPSocket::readFortune()
 
 			readedBufferSize_ = tcpSocket_->bytesAvailable();
 			incomeDataBuffer_->append(tcpSocket_->readAll());
-
-			return; // finish reading this message, waiting for the future data
 		}
 	} else {
 		// more data package is coming
@@ -73,6 +71,10 @@ void AMDSClientTCPSocket::readFortune()
 			inDataStream = new AMDSDataStream(incomeDataBuffer_);
 		}
 	}
+
+	// finish reading this message, waiting for the future data
+	if (waitingMorePackages_)
+		return;
 
 	AMDSClientRequest *clientRequest = inDataStream->decodeAndInstantiateClientRequestType();
 	inDataStream->read(*clientRequest);

--- a/source/Connection/AMDSClientTCPSocket.cpp
+++ b/source/Connection/AMDSClientTCPSocket.cpp
@@ -19,6 +19,11 @@ AMDSClientTCPSocket::AMDSClientTCPSocket(const QString host, const quint16 port,
 	socketKey_ = "";
 	tcpSocket_ = new QTcpSocket(this);
 
+	waitingMorePackages_ = false;
+	readedBufferSize_ = 0;
+	expectedBufferSize_ = 0;
+	incomeDataBuffer_ = new QByteArray();
+
 	connect(tcpSocket_, SIGNAL(readyRead()), this, SLOT(readFortune()));
 	connect(tcpSocket_, SIGNAL(error(QAbstractSocket::SocketError)), this, SLOT(onSocketError(QAbstractSocket::SocketError)));
 
@@ -41,17 +46,36 @@ void AMDSClientTCPSocket::readFortune()
 	if (tcpSocket_->bytesAvailable() < (int)sizeof(quint32))
 		return;
 
-	quint32 blockSize;
+	AMDSDataStream *inDataStream = new AMDSDataStream(tcpSocket_);
+	inDataStream->setVersion(QDataStream::Qt_4_0);
 
-	AMDSDataStream inDataStream(tcpSocket_);
-	inDataStream.setVersion(QDataStream::Qt_4_0);
+	if (!waitingMorePackages_) {
+		*inDataStream >> expectedBufferSize_;
 
-	inDataStream >> blockSize;
-	if (tcpSocket_->bytesAvailable() < blockSize)
-		return;
+		if (tcpSocket_->bytesAvailable() < expectedBufferSize_) {
+			// more data package is expecting, we need to buffer the current ones
+			waitingMorePackages_ = true;
+			incomeDataBuffer_->clear();
 
-	AMDSClientRequest *clientRequest = inDataStream.decodeAndInstantiateClientRequestType();
-	inDataStream.read(*clientRequest);
+			readedBufferSize_ = tcpSocket_->bytesAvailable();
+			incomeDataBuffer_->append(tcpSocket_->readAll());
+
+			return; // finish reading this message, waiting for the future data
+		}
+	} else {
+		// more data package is coming
+		readedBufferSize_ += tcpSocket_->bytesAvailable();
+		incomeDataBuffer_->append(tcpSocket_->readAll());
+
+		if (readedBufferSize_ == expectedBufferSize_) {
+			waitingMorePackages_ = false;
+
+			inDataStream = new AMDSDataStream(incomeDataBuffer_);
+		}
+	}
+
+	AMDSClientRequest *clientRequest = inDataStream->decodeAndInstantiateClientRequestType();
+	inDataStream->read(*clientRequest);
 
 	switch (clientRequest->requestType()) {
 	case AMDSClientRequestDefinitions::Introspection:

--- a/source/Connection/AMDSClientTCPSocket.cpp
+++ b/source/Connection/AMDSClientTCPSocket.cpp
@@ -32,6 +32,8 @@ AMDSClientTCPSocket::AMDSClientTCPSocket(const QString host, const quint16 port,
 
 AMDSClientTCPSocket::~AMDSClientTCPSocket()
 {
+	incomeDataBuffer_->clear();
+
 	tcpSocket_->abort();
 	tcpSocket_->close();
 }
@@ -46,14 +48,14 @@ void AMDSClientTCPSocket::readFortune()
 	if (tcpSocket_->bytesAvailable() < (int)sizeof(quint32))
 		return;
 
-	AMDSDataStream *inDataStream = new AMDSDataStream(tcpSocket_);
-	inDataStream->setVersion(QDataStream::Qt_4_0);
-
+	AMDSDataStream *inDataStream ;
 	if (!waitingMorePackages_) {
+		inDataStream= new AMDSDataStream(tcpSocket_);
+		inDataStream->setVersion(QDataStream::Qt_4_0);
 		*inDataStream >> expectedBufferSize_;
 
 		if (tcpSocket_->bytesAvailable() < expectedBufferSize_) {
-			// more data package is expecting, we need to buffer the current ones
+			//more data package is expecting, we need to buffer the current ones
 			waitingMorePackages_ = true;
 			incomeDataBuffer_->clear();
 

--- a/source/Connection/AMDSClientTCPSocket.h
+++ b/source/Connection/AMDSClientTCPSocket.h
@@ -53,6 +53,11 @@ private:
 protected:
 	QTcpSocket *tcpSocket_;
 	QString socketKey_;
+
+	bool waitingMorePackages_;
+	quint32 readedBufferSize_;
+	quint32 expectedBufferSize_;
+	QByteArray *incomeDataBuffer_;
 };
 
 #endif // AMDSCLIENTTCPSOCKET_H

--- a/source/Connection/AMDSClientTCPSocket.h
+++ b/source/Connection/AMDSClientTCPSocket.h
@@ -42,6 +42,7 @@ public slots:
 	void requestData(QString &bufferName, quint64 updateInterval, QString handShakeSocketKey="");
 
 protected slots:
+	/// slot to handle the socket error signals
 	void onSocketError(QAbstractSocket::SocketError error);
 	/// slot to handle the data from server
 	void readFortune();
@@ -51,12 +52,18 @@ private:
 	void sendData(AMDSClientRequest *clientRequest);
 
 protected:
+	/// the handler of the socket connection
 	QTcpSocket *tcpSocket_;
+	/// the socket key
 	QString socketKey_;
 
+	/// flag to identify whether we are waiting for the second data package or not
 	bool waitingMorePackages_;
+	/// variable to remember how many bytes we already read
 	quint32 readedBufferSize_;
+	/// variable to remember how many bytes we suppose to read
 	quint32 expectedBufferSize_;
+	/// byte array to save the readed bytes temporarily
 	QByteArray *incomeDataBuffer_;
 };
 


### PR DESCRIPTION
https://github.com/acquaman/AcquamanDataServer/issues/49

For continuous request, when the data size is too large, the server will send the package in several messages. Client side should be able to combine those messages to parse the data
