### PR TITLE
Pull Request for Issue42: solve the AMDS server multiple data process called issue

### DIFF
--- a/source/AMDSCentralServer.cpp
+++ b/source/AMDSCentralServer.cpp
@@ -75,10 +75,10 @@ void AMDSCentralServer::onDataServerClientRequestReady(AMDSClientRequest *client
 			if (threadedBufferGroup) {
 				AMDSBufferGroup * bufferGroup = threadedBufferGroup->bufferGroup();
 				clientDataRequest->setBufferGroupInfo(threadedBufferGroup->bufferGroupInfo());
-				connect(bufferGroup, SIGNAL(clientRequestProcessed(AMDSClientRequest*)), dataServer_->server(), SLOT(onClientRequestProcessed(AMDSClientRequest*)));
 				bufferGroup->processClientRequest(clientRequest);
 			} else {
 				AMDSErrorMon::alert(this, 0, QString("Invalid client data request with buffer name: %1").arg(clientDataRequest->bufferName()));
+				emit clientRequestProcessed(clientRequest);
 			}
 		}
 	}
@@ -130,6 +130,11 @@ void AMDSCentralServer::initializeBufferGroup(quint64 maxCountSize)
 	energyBufferGroup_ = new AMDSBufferGroup(energyBufferGroupInfo, maxCountSize);
 	AMDSThreadedBufferGroup *energyThreadedBufferGroup = new AMDSThreadedBufferGroup(energyBufferGroup_);
 	bufferGroups_.insert(energyThreadedBufferGroup->bufferGroupInfo().name(), energyThreadedBufferGroup);
+
+	connect(mcpBufferGroup, SIGNAL(clientRequestProcessed(AMDSClientRequest*)), dataServer_->server(), SLOT(onClientRequestProcessed(AMDSClientRequest*)));
+	connect(amptek1BufferGroup_, SIGNAL(clientRequestProcessed(AMDSClientRequest*)), dataServer_->server(), SLOT(onClientRequestProcessed(AMDSClientRequest*)));
+	connect(energyBufferGroup_, SIGNAL(clientRequestProcessed(AMDSClientRequest*)), dataServer_->server(), SLOT(onClientRequestProcessed(AMDSClientRequest*)));
+
 }
 
 void AMDSCentralServer::startTimer()

--- a/source/AMDSCentralServer.cpp
+++ b/source/AMDSCentralServer.cpp
@@ -70,15 +70,15 @@ void AMDSCentralServer::onDataServerClientRequestReady(AMDSClientRequest *client
 	else{
 		AMDSClientDataRequest *clientDataRequest = qobject_cast<AMDSClientDataRequest*>(clientRequest);
 		if(clientDataRequest){
-			if(clientDataRequest->bufferName() == "Energy"){
-				clientDataRequest->setBufferGroupInfo(energyBufferGroup_->bufferGroupInfo());
-				connect(energyBufferGroup_, SIGNAL(clientRequestProcessed(AMDSClientRequest*)), dataServer_->server(), SLOT(onClientRequestProcessed(AMDSClientRequest*)));
-				energyBufferGroup_->processClientRequest(clientRequest);
-			}
-			if(clientDataRequest->bufferName() == "Amptek1"){
-				clientDataRequest->setBufferGroupInfo(amptek1BufferGroup_->bufferGroupInfo());
-				connect(amptek1BufferGroup_, SIGNAL(clientRequestProcessed(AMDSClientRequest*)), dataServer_->server(), SLOT(onClientRequestProcessed(AMDSClientRequest*)));
-				amptek1BufferGroup_->processClientRequest(clientRequest);
+
+			AMDSThreadedBufferGroup *threadedBufferGroup = bufferGroups_.value(clientDataRequest->bufferName(), 0);
+			if (threadedBufferGroup) {
+				AMDSBufferGroup * bufferGroup = threadedBufferGroup->bufferGroup();
+				clientDataRequest->setBufferGroupInfo(threadedBufferGroup->bufferGroupInfo());
+				connect(bufferGroup, SIGNAL(clientRequestProcessed(AMDSClientRequest*)), dataServer_->server(), SLOT(onClientRequestProcessed(AMDSClientRequest*)));
+				bufferGroup->processClientRequest(clientRequest);
+			} else {
+				AMDSErrorMon::alert(this, 0, QString("Invalid client data request with buffer name: %1").arg(clientDataRequest->bufferName()));
 			}
 		}
 	}

--- a/source/AMDSThreadedBufferGroup.cpp
+++ b/source/AMDSThreadedBufferGroup.cpp
@@ -17,6 +17,11 @@ AMDSBufferGroupInfo AMDSThreadedBufferGroup::bufferGroupInfo() const{
 	return bufferGroup_->bufferGroupInfo();
 }
 
+AMDSBufferGroup * AMDSThreadedBufferGroup::bufferGroup() const
+{
+	return bufferGroup_;
+}
+
 void AMDSThreadedBufferGroup::onBufferGroupThreadStarted(){
 	emit bufferGroupReady();
 }

--- a/source/AMDSThreadedBufferGroup.h
+++ b/source/AMDSThreadedBufferGroup.h
@@ -13,6 +13,7 @@ public:
 	AMDSThreadedBufferGroup(AMDSBufferGroup *bufferGroup, QObject *parent = 0);
 
 	AMDSBufferGroupInfo bufferGroupInfo() const;
+	AMDSBufferGroup * bufferGroup() const;
 
 signals:
 	void bufferGroupReady();


### PR DESCRIPTION
https://github.com/acquaman/AcquamanDataServer/issues/42

As mentioned in the issue, the signal `clientRequestRequested` of bufferGroup is connected as many times as the request message, and no disconnect when the client connect is dismissed. Actually, we only need the bufferGroup to connect once. 
