### PR TITLE
PullRequet for Issue14: add logic to deregister continuous message

### DIFF
--- a/source/AMDSBufferGroup.cpp
+++ b/source/AMDSBufferGroup.cpp
@@ -89,7 +89,7 @@ void AMDSBufferGroup::populateData(AMDSClientStartTimePlusCountDataRequest* clie
 	QDateTime startTime = clientDataRequest->startTime();
 	quint64 count = clientDataRequest->count();
 
-	int startIndex = lowerBound(startTime);
+	int startIndex = getDataIndexByDateTime(startTime);
 
 	if(startIndex == -1)
 		clientDataRequest->setErrorMessage(QString("Could not locate data for time %1").arg(startTime.toString()));
@@ -111,8 +111,8 @@ void AMDSBufferGroup::populateData(AMDSClientStartTimeToEndTimeDataRequest* clie
 	QDateTime startTime = clientDataRequest->startTime();
 	QDateTime endTime = clientDataRequest->endTime();
 
-	int startIndex = lowerBound(startTime);
-	int endIndex = lowerBound(endTime);
+	int startIndex = getDataIndexByDateTime(startTime);
+	int endIndex = getDataIndexByDateTime(endTime);
 
 	if(startIndex == -1) {
 		clientDataRequest->setErrorMessage(QString("Could not locate data for start time %1 (ReqType: 4)").arg(startTime.toString()));
@@ -129,7 +129,7 @@ void AMDSBufferGroup::populateData(AMDSClientMiddleTimePlusCountBeforeAndAfterDa
 	int countBefore = clientDataRequest->countBefore();
 	int countAfter = clientDataRequest->countAfter();
 
-	int middleIndex = lowerBound(middleTime);
+	int middleIndex = getDataIndexByDateTime(middleTime);
 	if(middleIndex == -1) {
 		clientDataRequest->setErrorMessage(QString("Could not locate data for middle time %1 (ReqType: 5)").arg(middleTime.toString()));
 	} else {
@@ -139,7 +139,7 @@ void AMDSBufferGroup::populateData(AMDSClientMiddleTimePlusCountBeforeAndAfterDa
 
 void AMDSBufferGroup::populateData(AMDSClientContinuousDataRequest *clientDataRequest)
 {
-	int startIndex = lowerBound(clientDataRequest->lastFetchTime());
+	int startIndex = getDataIndexByDateTime(clientDataRequest->lastFetchTime());
 	if(startIndex == -1)
 		clientDataRequest->setErrorMessage(QString("Could not locate data for time %1").arg(clientDataRequest->lastFetchTime().toString()));
 	else {
@@ -152,7 +152,7 @@ void AMDSBufferGroup::populateData(AMDSClientContinuousDataRequest *clientDataRe
 	}
 }
 
-int AMDSBufferGroup::lowerBound(const QDateTime &dwellTime)
+int AMDSBufferGroup::getDataIndexByDateTime(const QDateTime &dwellTime)
 {
 	if (dataHolders_.isEmpty())
 		return -1;

--- a/source/AMDSBufferGroup.h
+++ b/source/AMDSBufferGroup.h
@@ -75,7 +75,7 @@ protected:
 
 	/// Helper function that returns the index in the buffer 1 before the given dwellTime, or at the point at
 	/// which the given dwellTime would occur within the buffer, if an exact match is not found.
-	int lowerBound(const QDateTime& dwellTime);
+	int getDataIndexByDateTime(const QDateTime& dwellTime);
 
 protected:
 	AMDSBufferGroupInfo bufferGroupInfo_;

--- a/source/AMDSCentralServer.cpp
+++ b/source/AMDSCentralServer.cpp
@@ -74,9 +74,6 @@ void AMDSCentralServer::onDataServerClientRequestReady(AMDSClientRequest *client
 			if ( clientDataRequest->isContinuousMessage()) {
 				AMDSClientContinuousDataRequest *continuousDataRequest = qobject_cast<AMDSClientContinuousDataRequest*>(clientDataRequest);
 				if (!continuousDataRequest->startContinuousRequestTimer()) {
-					continuousDataRequest->deleteLater();
-					dataServer_->server()->disconnectFromHost(continuousDataRequest->socketKey());
-
 					return;
 				}
 

--- a/source/AMDSClient.cpp
+++ b/source/AMDSClient.cpp
@@ -152,11 +152,6 @@ void AMDSClient::requestNewFortune()
 		selectedBufferNames.append(index.data(Qt::DisplayRole).toString());
 	}
 
-	if (selectedBufferNames.count() == 0) {
-		QMessageBox::information( this, "Fortune Client", "Didn't select any buffer(s)!");
-		return;
-	}
-
 	quint8 requestTypeId = (quint8)requestType->currentIndex();
 	QString bufferName = selectedBufferNames.value(0);
 	QDateTime time1 = time1Edit->dateTime();
@@ -170,6 +165,13 @@ void AMDSClient::requestNewFortune()
 	connect(clientTCPSocket, SIGNAL(socketError(AMDSClientTCPSocket*, QAbstractSocket::SocketError)), this, SLOT(onSocketError(AMDSClientTCPSocket*, QAbstractSocket::SocketError)));
 
 	AMDSClientRequestDefinitions::RequestType clientRequestType = (AMDSClientRequestDefinitions::RequestType)requestTypeId;
+	if (	(selectedBufferNames.count() == 0)
+		 && (clientRequestType != AMDSClientRequestDefinitions::Continuous )
+		 && (clientRequestType != AMDSClientRequestDefinitions::Statistics)) {
+		QMessageBox::information( this, "Fortune Client", "Didn't select any buffer(s)!");
+		return;
+	}
+
 	switch(clientRequestType) {
 	case AMDSClientRequestDefinitions::Introspection:
 		clientTCPSocket->requestData(bufferName);

--- a/source/AMDSTCPDataServer.cpp
+++ b/source/AMDSTCPDataServer.cpp
@@ -50,13 +50,6 @@ AMDSTCPDataServer::~AMDSTCPDataServer()
 	stop();
 }
 
-void AMDSTCPDataServer::disconnectFromHost(QString socketKey)
-{
-	QTcpSocket* requestingSocket = clientSockets_.value(socketKey, 0);
-	if(requestingSocket != 0)
-		requestingSocket->disconnectFromHost();
-}
-
 void AMDSTCPDataServer::displayClients()
 {
 	if(clientSockets_.isEmpty())
@@ -171,10 +164,15 @@ void AMDSTCPDataServer::onClientRequestProcessed(AMDSClientRequest *processedReq
 	}
 
 	if (!processedClientDataRequest || !processedClientDataRequest->isContinuousMessage()) {
-		processedRequest->deleteLater();
-		if (requestingSocket)
-			requestingSocket->disconnectFromHost();
+		onClientRequestTaskAccomplished(processedRequest);
 	}
+}
+
+void AMDSTCPDataServer::disconnectFromHost(QString socketKey)
+{
+	QTcpSocket* requestingSocket = clientSockets_.value(socketKey, 0);
+	if(requestingSocket != 0)
+		requestingSocket->disconnectFromHost();
 }
 
 void AMDSTCPDataServer::sessionOpened()
@@ -339,7 +337,7 @@ void AMDSTCPDataServer::onClientSentRequest(const QString &clientKey)
 			if(clientContinuousDataRequest){
 				if (clientContinuousDataRequest->isHandShakingMessage()) {
 					QString socketKey = clientContinuousDataRequest->handShakeSocketKey();
-					AMDSClientContinuousDataRequest *handShakingclientDataRequest = qobject_cast<AMDSClientContinuousDataRequest*>(continuousDataRequests_.value(socketKey));
+					AMDSClientContinuousDataRequest *handShakingclientDataRequest = qobject_cast<AMDSClientContinuousDataRequest*>(activeContinuousDataRequestList_.value(socketKey));
 					if (handShakingclientDataRequest) {
 						handShakingclientDataRequest->setHandShakeTime(QDateTime::currentDateTime());
 						AMDSErrorMon::information(this, 0, QString("Hand shaking with socketKey (%1)").arg(socketKey));
@@ -347,17 +345,32 @@ void AMDSTCPDataServer::onClientSentRequest(const QString &clientKey)
 						AMDSErrorMon::alert(this, 0, QString("Didn't find hand shaking message with socketKey (%1)").arg(socketKey));
 					}
 
-					clientContinuousDataRequest->deleteLater();
-					requestingSocket->disconnectFromHost();
+					onClientRequestTaskAccomplished(clientContinuousDataRequest);
 					return;
 				} else {
-					continuousDataRequests_.insert(clientContinuousDataRequest->socketKey(), clientContinuousDataRequest);
+					activeContinuousDataRequestList_.insert(clientContinuousDataRequest->socketKey(), clientContinuousDataRequest);
 					connect(clientContinuousDataRequest, SIGNAL(sendNewContinuousDataRequest(AMDSClientRequest*)), this, SIGNAL(clientRequestRead(AMDSClientRequest*)));
+					connect(clientContinuousDataRequest, SIGNAL(clientRequestTaskAccomplished(AMDSClientRequest*)), this, SLOT(onClientRequestTaskAccomplished(AMDSClientRequest*)));
 				}
 			}
 		}
 
 		emit clientRequestRead(clientRequest);
+	}
+}
+
+void AMDSTCPDataServer::onClientRequestTaskAccomplished(AMDSClientRequest *clientRequest)
+{
+	if (clientRequest) {
+		if (clientRequest->isContinuousMessage() && activeContinuousDataRequestList_.contains(clientRequest->socketKey())) {
+			disconnect(clientRequest, SIGNAL(sendNewContinuousDataRequest(AMDSClientRequest*)), this, SIGNAL(clientRequestRead(AMDSClientRequest*)));
+			disconnect(clientRequest, SIGNAL(clientRequestTaskAccomplished(AMDSClientRequest*)), this, SLOT(onClientRequestTaskAccomplished(AMDSClientRequest*)));
+
+			activeContinuousDataRequestList_.remove(clientRequest->socketKey());
+		}
+
+		disconnectFromHost(clientRequest->socketKey());
+		clientRequest->deleteLater();
 	}
 }
 

--- a/source/AMDSTCPDataServer.cpp
+++ b/source/AMDSTCPDataServer.cpp
@@ -348,12 +348,12 @@ bool AMDSTCPDataServer::onClientContinuousRequestReceived(AMDSClientRequest *cli
 	if(clientContinuousDataRequest){
 		if (clientContinuousDataRequest->isHandShakingMessage()) {
 			QString socketKey = clientContinuousDataRequest->handShakeSocketKey();
-			AMDSClientContinuousDataRequest *handShakingclientDataRequest = qobject_cast<AMDSClientContinuousDataRequest*>(activeContinuousDataRequestList_.value(socketKey));
-			if (handShakingclientDataRequest) {
-				handShakingclientDataRequest->setHandShakeTime(QDateTime::currentDateTime());
-				AMDSErrorMon::information(this, 0, QString("Hand shaking with socketKey (%1)").arg(socketKey));
+			AMDSClientContinuousDataRequest *activeContinuousDataRequest = qobject_cast<AMDSClientContinuousDataRequest*>(activeContinuousDataRequestList_.value(socketKey));
+			if (activeContinuousDataRequest) {
+				AMDSErrorMon::information(this, 0, QString("Hand shaking with message (%1)").arg(socketKey));
+				activeContinuousDataRequest->handShaking(clientContinuousDataRequest);
 			} else {
-				AMDSErrorMon::alert(this, 0, QString("Didn't find hand shaking message with socketKey (%1)").arg(socketKey));
+				AMDSErrorMon::alert(this, 0, QString("Didn't find hand shaking message (%1)").arg(socketKey));
 			}
 
 			onClientRequestTaskAccomplished(clientContinuousDataRequest);

--- a/source/AMDSTCPDataServer.h
+++ b/source/AMDSTCPDataServer.h
@@ -80,6 +80,7 @@ protected slots:
 	/// Slot to handle client request task accomplished, the related resouces can be released
 	void onClientRequestTaskAccomplished(AMDSClientRequest *clientRequest);
 
+	/// Slot to handle the timeout signals of statistics timers
 	void onTenMillisecondStatsTimerTimeout();
 	void onHundredMillisecondStatsTimerTimeout();
 	void onOneSecondStatsTimerTimeout();

--- a/source/AMDSTCPDataServer.h
+++ b/source/AMDSTCPDataServer.h
@@ -33,13 +33,12 @@ public:
 	/// Default destructor for AMDSTcpDataServer. Calls stop
 	~AMDSTCPDataServer();
 
-	/// to disconnect the given connection from the host
-	void disconnectFromHost(QString socketKey);
-
 signals:
 	/// error signal
 	void error(quint8 errorLevel, quint16 errorCode, const QString &errorString);
 	void requestInfo();
+
+	/// the signal of new client request read from socket
 	void clientRequestRead(AMDSClientRequest*);
 
 public slots:
@@ -59,6 +58,9 @@ public slots:
 	void onClientRequestProcessed(AMDSClientRequest *processedRequest);
 
 protected slots:
+	/// to disconnect the given connection from the host
+	void disconnectFromHost(QString socketKey);
+
 	/// Slot which sets the server to be listening. Automatically called from within the start() function, or
 	/// if a session is required, when the session is opened
 	void sessionOpened();
@@ -71,8 +73,8 @@ protected slots:
 	/// Slot which handles a client sending a request to the server. Builds a ClientRequest* from the provided data,
 	/// if the request is well formed, and emits requestData()
 	void onClientSentRequest(const QString& clientKey);
-//	/// Slot which handles the timeout which signals a continuous data request needs a new aggregate of data.
-//	void onContinuousDataRequestTimer(const QString& clientKey);
+	/// Slot to handle client request task accomplished, the related resouces can be released
+	void onClientRequestTaskAccomplished(AMDSClientRequest *clientRequest);
 
 	void onTenMillisecondStatsTimerTimeout();
 	void onHundredMillisecondStatsTimerTimeout();
@@ -95,7 +97,7 @@ protected:
 	/// the ip_address:port in the format xx.xx.xx.xx:xxxxx to the size of the request
 	QHash<QString, int> clientSocketDataInProgress_;
 	/// A map storing continuous data requests from clients
-	QHash<QString, AMDSClientRequest*> continuousDataRequests_;
+	QHash<QString, AMDSClientRequest*> activeContinuousDataRequestList_;
 
 	/// A signal mapper which allows for us to listen to the disonnect signal from all the client sockets
 	/// currently connected. Mapped on the same string as the clientSockets_ hash:

--- a/source/AMDSTCPDataServer.h
+++ b/source/AMDSTCPDataServer.h
@@ -73,6 +73,10 @@ protected slots:
 	/// Slot which handles a client sending a request to the server. Builds a ClientRequest* from the provided data,
 	/// if the request is well formed, and emits requestData()
 	void onClientSentRequest(const QString& clientKey);
+	/// Slot to handle the newly received statics client request message
+	void onClientStaticsRequestReceived(AMDSClientRequest *clientRequest);
+	/// Slot to handle the newly received continuous client request message, return true if the message is done handle
+	bool onClientContinuousRequestReceived(AMDSClientRequest *clientRequest);
 	/// Slot to handle client request task accomplished, the related resouces can be released
 	void onClientRequestTaskAccomplished(AMDSClientRequest *clientRequest);
 

--- a/source/ClientRequest/AMDSClientContinuousDataRequest.cpp
+++ b/source/ClientRequest/AMDSClientContinuousDataRequest.cpp
@@ -151,6 +151,8 @@ bool AMDSClientContinuousDataRequest::startContinuousRequestTimer()
 	if (messageExpired) {
 		setErrorMessage(QString("(msg %1) continuous update expired!").arg(socketKey()));
 		AMDSErrorMon::alert(this, 0, errorMessage());
+
+		emit clientRequestTaskAccomplished(this);
 	} else {
 		AMDSErrorMon::information(this, 0, QString("(msg %1) update interval: %2!").arg(socketKey()).arg(updateInterval()));
 		continuousDataRequestTimer_.singleShot(updateInterval(), this, SLOT(onDataRequestTimerTimeout()));

--- a/source/ClientRequest/AMDSClientContinuousDataRequest.cpp
+++ b/source/ClientRequest/AMDSClientContinuousDataRequest.cpp
@@ -161,6 +161,41 @@ bool AMDSClientContinuousDataRequest::startContinuousRequestTimer()
 	return !messageExpired;
 }
 
+/**
+  Handshaking logic:
+	 - if the handShaking message contains no interested buffer name, the corresponding active message will be deregisterred;
+	 - if the handShaking message contains buffer names, the active buffer names not in the handshake buffer names will NOT be tracked anymore
+	 - if all the active buffername is deactived, the corresponding active message will be forced to be deregisterred;
+*/
+void AMDSClientContinuousDataRequest::handShaking(AMDSClientContinuousDataRequest *handShakingMessage)
+{
+	setHandShakeTime(QDateTime::currentDateTime());
+
+	QStringList handShakeBufferNames = handShakingMessage->bufferNames();
+	if (handShakeBufferNames.size() == 0) {
+		AMDSErrorMon::alert(this, 0, QString("(msg %1): deregistered by request.").arg(socketKey()));
+		emit clientRequestTaskAccomplished(this);
+	} else {
+		foreach (QString bufferName, bufferNames()) {
+			if (!handShakeBufferNames.contains(bufferName)) {
+				// this buffer name is no longer interested, removed from the active list
+				AMDSClientRequest *dataRequest = bufferDataRequestList_.value(bufferName);
+				bufferDataRequestList_.remove(bufferName);
+				dataRequest->deleteLater();
+
+				bufferNameList_.removeAt(bufferNameList_.indexOf(bufferName));
+
+				AMDSErrorMon::alert(this, 0, QString("(msg %1): buffer (%2) is no longer traced.").arg(socketKey()).arg(bufferName));
+			}
+		}
+
+		if (bufferDataRequestList_.size() == 0) {
+			AMDSErrorMon::alert(this, 0, QString("(msg %1): force-deregistered by request since no more active interested buffer.").arg(socketKey()));
+			emit clientRequestTaskAccomplished(this);
+		}
+	}
+}
+
 void AMDSClientContinuousDataRequest::onDataRequestTimerTimeout()
 {
 	emit sendNewContinuousDataRequest(this);

--- a/source/ClientRequest/AMDSClientContinuousDataRequest.h
+++ b/source/ClientRequest/AMDSClientContinuousDataRequest.h
@@ -70,6 +70,8 @@ public:
 signals:
 	/// SIGNAL of new message requst
 	void sendNewContinuousDataRequest(AMDSClientRequest* message);
+	/// SIGNAL of task accomplished, the related resources can be removed
+	void clientRequestTaskAccomplished(AMDSClientRequest* message);
 
 protected slots:
 	/// to handle the timeout message of the timer: to send the new message

--- a/source/ClientRequest/AMDSClientContinuousDataRequest.h
+++ b/source/ClientRequest/AMDSClientContinuousDataRequest.h
@@ -67,6 +67,11 @@ public:
 	/// start the coninuousRequestTimer for next message
 	bool startContinuousRequestTimer();
 
+	/// perform hand shaking with the client
+	///    - if the handShaking message contains no interested buffername or interested buffers has no intersection with existing ones,
+	///      the current message will be deregistered
+	void handShaking(AMDSClientContinuousDataRequest *handShakingMessage);
+
 signals:
 	/// SIGNAL of new message requst
 	void sendNewContinuousDataRequest(AMDSClientRequest* message);

--- a/source/ClientRequest/AMDSClientDataRequest.h
+++ b/source/ClientRequest/AMDSClientDataRequest.h
@@ -17,12 +17,6 @@ public:
 	/// Copy constructor
 	AMDSClientDataRequest(const AMDSClientDataRequest& other);
 
-	/// returns whether this is a data client data request
-	virtual bool isDataClientRequest() { return true; }
-
-	/// returns whether this is a continuous message
-	virtual bool isContinuousMessage() { return false;}
-
 	/// The string identifier for the buffer data is being request from or received from
 	inline QString bufferName() const { return bufferName_; }
 	/// Whether or not the client has requested that the statusData is included in the response

--- a/source/ClientRequest/AMDSClientRequest.cpp
+++ b/source/ClientRequest/AMDSClientRequest.cpp
@@ -33,6 +33,14 @@ AMDSClientRequest& AMDSClientRequest::operator =(const AMDSClientRequest &other)
 	return (*this);
 }
 
+bool AMDSClientRequest::isDataClientRequest() {
+	return     requestType() == AMDSClientRequestDefinitions::StartTimePlusCount
+			|| requestType() == AMDSClientRequestDefinitions::RelativeCountPlusCount
+			|| requestType() == AMDSClientRequestDefinitions::StartTimeToEndTime
+			|| requestType() == AMDSClientRequestDefinitions::MiddleTimePlusCountBeforeAndAfter
+			|| requestType() == AMDSClientRequestDefinitions::Continuous ;
+}
+
 bool AMDSClientRequest::writeToDataStream(AMDSDataStream *dataStream) const
 {
 	*dataStream << socketKey_;

--- a/source/ClientRequest/AMDSClientRequest.h
+++ b/source/ClientRequest/AMDSClientRequest.h
@@ -27,8 +27,12 @@ public:
 	/// Overload of the assignment operator. Performs a deep copy. DOES NOT MAINTAIN QOBJECT PARENTAGE.
 	AMDSClientRequest& operator=(const AMDSClientRequest& other);
 
+	/// returns whether this is a statistics message
+	inline bool isStatisticsMessage() { return requestType() == AMDSClientRequestDefinitions::Statistics; }
 	/// returns whether this is a data client data request
-	virtual bool isDataClientRequest() { return false; }
+	bool isDataClientRequest();
+	/// returns whether this is a continuous message
+	inline bool isContinuousMessage() { return requestType() == AMDSClientRequestDefinitions::Continuous;}
 
 	/// A key used to identify the client socket on which the request was made
 	inline QString socketKey() const { return socketKey_; }

--- a/source/Connection/AMDSClientTCPSocket.cpp
+++ b/source/Connection/AMDSClientTCPSocket.cpp
@@ -212,6 +212,11 @@ void AMDSClientTCPSocket::requestData(QString &bufferName, QDateTime &middleTime
 
 void AMDSClientTCPSocket::requestData(QStringList &bufferNames, quint64 updateInterval, QString handShakeSocketKey)
 {
+	if (bufferNames.length() == 0 && handShakeSocketKey.length() == 0) {
+		AMDSErrorMon::alert(this, 0, QString("AMDSClientTCPSocket::Failed to parse continuousDataRequest without interested buffer name(s) and handShakeSocketKey"));
+		return;
+	}
+
 	AMDSClientRequestDefinitions::RequestType clientRequestType = AMDSClientRequestDefinitions::Continuous;
 	AMDSClientRequest *clientRequest = AMDSClientRequestSupport::instantiateClientRequestFromType(clientRequestType);
 	if (!clientRequest) {


### PR DESCRIPTION
https://github.com/acquaman/AcquamanDataServer/issues/14

Add logic to deregister continous messages:
- when there is no bufferNames (or doesn't contain existing interested bufferNames) in the handShaking message, the corresponding active continuous message (handshake key) will be deregisterred.

---

NOTE:
  this branch is based on branch 13, which means, you only need the review the commits after https://github.com/acquaman/AcquamanDataServer/commit/479f1da520e14656d94e97fdc2316bf525f94a29.

I set the PR to commit into master for a better network graph
