### PR TITLE
Pull Request for Issue60: Add error codes for ClientRequest read/write operation

### DIFF
--- a/source/AMDSDataStream.cpp
+++ b/source/AMDSDataStream.cpp
@@ -327,7 +327,11 @@ void AMDSDataStream::encodeClientRequestType(const AMDSClientRequest &clientRequ
 }
 
 void AMDSDataStream::write(const AMDSClientRequest &clientRequest){
-	clientRequest.writeToDataStream(this);
+	int errorCode = clientRequest.writeToDataStream(this);
+	if (errorCode != AMDS_CLIENTREQUEST_SUCCESS) {
+		QString errorMessage = AMDSClientRequestDefinitions::errorMessage(errorCode, AMDSClientRequestDefinitions::Write, clientRequest.requestType());
+		AMDSErrorMon::alert(0, errorCode, errorMessage);
+	}
 }
 
 AMDSClientRequestDefinitions::RequestType AMDSDataStream::decodeRequestType(){
@@ -347,12 +351,16 @@ AMDSClientRequest* AMDSDataStream::decodeAndInstantiateClientRequestType(){
 
 	AMDSClientRequest* clientRequest = AMDSClientRequestSupport::instantiateClientRequestFromType(clientRequestType);
 	if (!clientRequest) {
-		qDebug() << QString("AMDSDataStream::Failed to parse clientRequest for type: %s").arg(clientRequestType);
+		AMDSErrorMon::information(0, 0, QString("AMDSDataStream::Failed to parse clientRequest for type: %s").arg(clientRequestType));
 	}
 
 	return clientRequest;
 }
 
 void AMDSDataStream::read(AMDSClientRequest &clientRequest){
-	clientRequest.readFromDataStream(this);
+	int errorCode = clientRequest.readFromDataStream(this);
+	if (errorCode != AMDS_CLIENTREQUEST_SUCCESS) {
+		QString errorMessage = AMDSClientRequestDefinitions::errorMessage(errorCode, AMDSClientRequestDefinitions::Read, clientRequest.requestType());
+		AMDSErrorMon::alert(0, errorCode, errorMessage);
+	}
 }

--- a/source/ClientRequest/AMDSClientContinuousDataRequest.cpp
+++ b/source/ClientRequest/AMDSClientContinuousDataRequest.cpp
@@ -68,37 +68,43 @@ bool AMDSClientContinuousDataRequest::isExpired()
 	return timeSpanInSecond > 60;
 }
 
-bool AMDSClientContinuousDataRequest::writeToDataStream(AMDSDataStream *dataStream) const
+int AMDSClientContinuousDataRequest::writeToDataStream(AMDSDataStream *dataStream) const
 {
-	if(!AMDSClientDataRequest::writeToDataStream(dataStream))
-		return false;
+	int errorCode = AMDSClientDataRequest::writeToDataStream(dataStream);
+	if( errorCode != AMDS_CLIENTREQUEST_SUCCESS)
+		return errorCode;
 
 	*dataStream << updateInterval();
 	if(dataStream->status() != QDataStream::Ok)
-		return false;
+		return AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_UPDATE_INTERVAL;
 
 	*dataStream << handShakeSocketKey();
 	if(dataStream->status() != QDataStream::Ok)
-		return false;
+		return AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_HANDSHAKE_SOCKET_KEY;
 
-	return true;
+	return AMDS_CLIENTREQUEST_SUCCESS;
 }
 
-bool AMDSClientContinuousDataRequest::readFromDataStream(AMDSDataStream *dataStream)
+int AMDSClientContinuousDataRequest::readFromDataStream(AMDSDataStream *dataStream)
 {
-	if(!AMDSClientDataRequest::readFromDataStream(dataStream))
-		return false;
+	int errorCode = AMDSClientDataRequest::readFromDataStream(dataStream);
+	if( errorCode != AMDS_CLIENTREQUEST_SUCCESS)
+		return errorCode;
 
 	quint32 readUpdateInterval;
 	*dataStream >> readUpdateInterval;
+	if(dataStream->status() != QDataStream::Ok)
+		return AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_UPDATE_INTERVAL;
 
 	QString readHandShakeSocketKey;
 	*dataStream >> readHandShakeSocketKey;
+	if(dataStream->status() != QDataStream::Ok)
+		return AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_HANDSHAKE_SOCKET_KEY;
 
 	setUpdateInterval(readUpdateInterval);
 	setHandShakeSocketKey(readHandShakeSocketKey);
 
-	return true;
+	return AMDS_CLIENTREQUEST_SUCCESS;
 }
 
 bool AMDSClientContinuousDataRequest::startContinuousRequestTimer()

--- a/source/ClientRequest/AMDSClientContinuousDataRequest.h
+++ b/source/ClientRequest/AMDSClientContinuousDataRequest.h
@@ -44,10 +44,10 @@ public:
 	/// Sets the last handshake time for the data request
 	inline void setHandShakeTime(const QDateTime &handShakeTime) { lastHandShakeTime_ = handShakeTime; }
 
-	/// Writes this AMDSClientContinuousRequest to an AMDSDataStream, returns true if no errors are encountered
-	virtual bool writeToDataStream(AMDSDataStream *dataStream) const;
-	/// Reads this AMDSClientContinuousRequest from the AMDSDataStream, returns true if no errors are encountered
-	virtual bool readFromDataStream(AMDSDataStream *dataStream);
+	/// Writes this AMDSClientContinuousRequest to an AMDSDataStream, returns 0 if no errors are encountered
+	virtual int writeToDataStream(AMDSDataStream *dataStream) const;
+	/// Reads this AMDSClientContinuousRequest from the AMDSDataStream, returns 0 if no errors are encountered
+	virtual int readFromDataStream(AMDSDataStream *dataStream);
 
 	/// start the coninuousRequestTimer for next message
 	bool startContinuousRequestTimer();

--- a/source/ClientRequest/AMDSClientDataRequest.cpp
+++ b/source/ClientRequest/AMDSClientDataRequest.cpp
@@ -47,22 +47,23 @@ AMDSClientDataRequest& AMDSClientDataRequest::operator =(const AMDSClientDataReq
 	return (*this);
 }
 
-bool AMDSClientDataRequest::writeToDataStream(AMDSDataStream *dataStream) const
+int AMDSClientDataRequest::writeToDataStream(AMDSDataStream *dataStream) const
 {
-	if(!AMDSClientRequest::writeToDataStream(dataStream))
-		return false;
+	int errorCode = AMDSClientRequest::writeToDataStream(dataStream);
+	if(errorCode != AMDS_CLIENTREQUEST_SUCCESS)
+		return errorCode;
 
 	*dataStream << bufferName_;
 	if(dataStream->status() != QDataStream::Ok)
-		return false;
+		return AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_BUFFER_NAME;
 	*dataStream << includeStatusData_;
 	if(dataStream->status() != QDataStream::Ok)
-		return false;
+		return AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_INCLUDE_STATUS;
 
 	bool includeData = bufferGroupInfo_.includeData();
 	*dataStream << includeData;
 	if(dataStream->status() != QDataStream::Ok)
-		return false;
+		return AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_INCLUDE_DATA;
 
 	// write data to the data stream
 	if(includeData){
@@ -72,12 +73,12 @@ bool AMDSClientDataRequest::writeToDataStream(AMDSDataStream *dataStream) const
 		quint8 uniformDataType = (quint8)uniformDataType_;
 		*dataStream << uniformDataType;
 		if(dataStream->status() != QDataStream::Ok)
-			return false;
+			return AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_UNIFORM_DATA_TYPE;
 
 		quint16 dataCount = data_.count();
 		*dataStream << dataCount;
 		if(dataStream->status() != QDataStream::Ok || dataCount == 0)
-			return false;
+			return AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_DATA_COUNT;
 
 		bool encodeDataTypeInDataHolder = true;
 		AMDSDataTypeDefinitions::DataType underlyingDataType = data_.at(0)->dataType();
@@ -85,32 +86,33 @@ bool AMDSClientDataRequest::writeToDataStream(AMDSDataStream *dataStream) const
 			encodeDataTypeInDataHolder = false;
 		*dataStream << encodeDataTypeInDataHolder;
 		if(dataStream->status() != QDataStream::Ok)
-			return false;
+			return AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_DECODE_DATA_TYPE_IN_DATA_HOLDER;
 
 		if(!encodeDataTypeInDataHolder){
 			dataStream->encodeDataType(underlyingDataType);
 			if(dataStream->status() != QDataStream::Ok)
-				return false;
+				return AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_DATA_HOLDER_TYPE;
 		}
 
 		dataStream->encodeDataHolderType(*(data_.at(0)));
 		if(dataStream->status() != QDataStream::Ok)
-			return false;
+			return AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_DECODE_DATA_TYPE;
 
 		for(int x = 0, size = data_.count(); x < size; x++){
 			dataStream->write(*(data_.at(x)), encodeDataTypeInDataHolder);
 			if(dataStream->status() != QDataStream::Ok)
-				return false;
+				return AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_DATA_HOLDER_DATA;
 		}
 	}
 
-	return true;
+	return AMDS_CLIENTREQUEST_SUCCESS;
 }
 
-bool AMDSClientDataRequest::readFromDataStream(AMDSDataStream *dataStream)
+int AMDSClientDataRequest::readFromDataStream(AMDSDataStream *dataStream)
 {
-	if(!AMDSClientRequest::readFromDataStream(dataStream))
-		return false;
+	int errorCode = AMDSClientRequest::readFromDataStream(dataStream);
+	if(errorCode != AMDS_CLIENTREQUEST_SUCCESS)
+		return errorCode;
 
 	QString readBufferName;
 	bool readIncludeStatusData;
@@ -124,34 +126,34 @@ bool AMDSClientDataRequest::readFromDataStream(AMDSDataStream *dataStream)
 
 	*dataStream >> readBufferName;
 	if(dataStream->status() != QDataStream::Ok)
-		return false;
+		return AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_BUFFER_NAME;
 
 	*dataStream >> readIncludeStatusData;
 	if(dataStream->status() != QDataStream::Ok)
-		return false;
+		return AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_INCLUDE_STATUS;
 
 	*dataStream >> readIncludeData;
 	if(dataStream->status() != QDataStream::Ok)
-		return false;
+		return AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_INCLUDE_DATA;
 
 	if(readIncludeData){
 		dataStream->read(readBufferGroupInfo);
 		*dataStream >> readUniformDataType;
 		if(dataStream->status() != QDataStream::Ok)
-			return false;
+			return AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_UNIFORM_DATA_TYPE;
 
 		*dataStream >> readDataCount;
 		if(dataStream->status() != QDataStream::Ok)
-			return false;
+			return AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_DATA_COUNT;
 
 		*dataStream >> decodeDataTypeInDataHolder;
 		if(dataStream->status() != QDataStream::Ok)
-			return false;
+			return AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_DECODE_DATA_TYPE_IN_DATA_HOLDER;
 
 		if(!decodeDataTypeInDataHolder){
 			readDataType = dataStream->decodeDataType();
 			if(dataStream->status() != QDataStream::Ok)
-				return false;
+				return AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_DECODE_DATA_TYPE;
 		}
 		else
 			readDataType = AMDSDataTypeDefinitions::InvalidType;
@@ -159,17 +161,17 @@ bool AMDSClientDataRequest::readFromDataStream(AMDSDataStream *dataStream)
 		QString readDataHolderType;
 		readDataHolderType = dataStream->decodeDataHolderType();
 		if(readDataHolderType.isEmpty())
-			return false;
+			return AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_DATA_HOLDER_TYPE;
 
 		AMDSDataHolder *oneDataHolder = AMDSDataHolderSupport::instantiateDataHolderFromClassName(readDataHolderType);
 		if(!oneDataHolder)
-			return false;
+			return AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_INSTANTIATE_DATA_HOLDER;
 
 		for(int x = 0; x < readDataCount; x++){
 			oneDataHolder = AMDSDataHolderSupport::instantiateDataHolderFromClassName(readDataHolderType);
 			dataStream->read(*oneDataHolder, readDataType);
 			if(dataStream->status() != QDataStream::Ok)
-				return false;
+				return AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_DATA_HOLDER_DATA;
 			readDataHolder.append(oneDataHolder);
 		}
 	}
@@ -186,7 +188,7 @@ bool AMDSClientDataRequest::readFromDataStream(AMDSDataStream *dataStream)
 		data_.append(readDataHolder);
 	}
 
-	return true;
+	return AMDS_CLIENTREQUEST_SUCCESS;
 }
 
 bool AMDSClientDataRequest::validateResponse()

--- a/source/ClientRequest/AMDSClientDataRequest.h
+++ b/source/ClientRequest/AMDSClientDataRequest.h
@@ -43,10 +43,10 @@ public:
 	/// Clears the list of data holders
 	inline void clearData() { data_.clear(); }
 
-	/// Writes this AMDSClienDatatRequest to an AMDSDataStream, returns true if no errors are encountered
-	virtual bool writeToDataStream(AMDSDataStream *dataStream) const;
-	/// Reads this AMDSClientDataRequest from the AMDSDataStream, returns true if no errors are encountered
-	virtual bool readFromDataStream(AMDSDataStream *dataStream);
+	/// Writes this AMDSClienDatatRequest to an AMDSDataStream, returns 0 if no errors are encountered
+	virtual int writeToDataStream(AMDSDataStream *dataStream) const;
+	/// Reads this AMDSClientDataRequest from the AMDSDataStream, returns 0 if no errors are encountered
+	virtual int readFromDataStream(AMDSDataStream *dataStream);
 	/// validate the message response
 	virtual bool validateResponse();
 

--- a/source/ClientRequest/AMDSClientIntrospectionRequest.cpp
+++ b/source/ClientRequest/AMDSClientIntrospectionRequest.cpp
@@ -53,30 +53,32 @@ QStringList AMDSClientIntrospectionRequest::getAllBufferNames()
 	return bufferNames;
 }
 
-bool AMDSClientIntrospectionRequest::writeToDataStream(AMDSDataStream *dataStream) const
+int AMDSClientIntrospectionRequest::writeToDataStream(AMDSDataStream *dataStream) const
 {
-	if(!AMDSClientRequest::writeToDataStream(dataStream))
-		return false;
+	int errorCode = AMDSClientRequest::writeToDataStream(dataStream);
+	if( errorCode != AMDS_CLIENTREQUEST_SUCCESS)
+		return errorCode;
 
 	*dataStream << bufferName_;
 	if(dataStream->status() != QDataStream::Ok)
-		return false;
+		return AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_BUFFER_NAME;
 
 	quint16 bufferGroupInfosCount = bufferGroupInfos_.count();
 	*dataStream << bufferGroupInfosCount;
 	if(dataStream->status() != QDataStream::Ok)
-		return false;
+		return AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_BUFFER_GROUP_INFO_COUNT;
 
 	for(int x = 0, size = bufferGroupInfos_.count(); x < size; x++)
 		dataStream->write(bufferGroupInfos_.at(x));
 
-	return true;
+	return AMDS_CLIENTREQUEST_SUCCESS;
 }
 
-bool AMDSClientIntrospectionRequest::readFromDataStream(AMDSDataStream *dataStream)
+int AMDSClientIntrospectionRequest::readFromDataStream(AMDSDataStream *dataStream)
 {
-	if(!AMDSClientRequest::readFromDataStream(dataStream))
-		return false;
+	int errorCode = AMDSClientRequest::readFromDataStream(dataStream);
+	if( errorCode != AMDS_CLIENTREQUEST_SUCCESS)
+		return errorCode;
 
 	QString readBufferName;
 	quint16 readBufferGroupInfosCount;
@@ -84,23 +86,23 @@ bool AMDSClientIntrospectionRequest::readFromDataStream(AMDSDataStream *dataStre
 
 	*dataStream >> readBufferName;
 	if(dataStream->status() != QDataStream::Ok)
-		return false;
+		return AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_BUFFER_NAME;
 	*dataStream >> readBufferGroupInfosCount;
 	if(dataStream->status() != QDataStream::Ok)
-		return false;
+		return AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_BUFFER_GROUP_INFO_COUNT;
 
 	for(int x = 0, size = readBufferGroupInfosCount; x < size; x++){
 		AMDSBufferGroupInfo oneBufferGroupInfo("Invalid");
 		dataStream->read(oneBufferGroupInfo);
 		if(oneBufferGroupInfo.name() == "Invalid")
-			return false;
+			return AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_BUFFER_GROUP_INFO;
 		readBufferGroupInfos.append(oneBufferGroupInfo);
 	}
 
 	setBufferName(readBufferName);
 	bufferGroupInfos_.append(readBufferGroupInfos);
 
-	return true;
+	return AMDS_CLIENTREQUEST_SUCCESS;
 }
 
 bool AMDSClientIntrospectionRequest::validateResponse()

--- a/source/ClientRequest/AMDSClientIntrospectionRequest.h
+++ b/source/ClientRequest/AMDSClientIntrospectionRequest.h
@@ -38,10 +38,10 @@ public:
 	/// Clears the list of buffer group infos
 	inline void clearBufferGroupInfos() { bufferGroupInfos_.clear(); }
 
-	/// Writes this AMDSClientIntrospectionRequest to an AMDSDataStream, returns true if no errors are encountered
-	virtual bool writeToDataStream(AMDSDataStream *dataStream) const;
-	/// Reads this AMDSClientIntrospectionRequest from the AMDSDataStream, returns true if no errors are encountered
-	virtual bool readFromDataStream(AMDSDataStream *dataStream);
+	/// Writes this AMDSClientIntrospectionRequest to an AMDSDataStream, returns 0 if no errors are encountered
+	virtual int writeToDataStream(AMDSDataStream *dataStream) const;
+	/// Reads this AMDSClientIntrospectionRequest from the AMDSDataStream, returns 0 if no errors are encountered
+	virtual int readFromDataStream(AMDSDataStream *dataStream);
 	/// validate the message response
 	virtual bool validateResponse();
 

--- a/source/ClientRequest/AMDSClientMiddleTimePlusCountBeforeAndAfterDataRequest.cpp
+++ b/source/ClientRequest/AMDSClientMiddleTimePlusCountBeforeAndAfterDataRequest.cpp
@@ -41,28 +41,30 @@ AMDSClientMiddleTimePlusCountBeforeAndAfterDataRequest& AMDSClientMiddleTimePlus
 	return (*this);
 }
 
-bool AMDSClientMiddleTimePlusCountBeforeAndAfterDataRequest::writeToDataStream(AMDSDataStream *dataStream) const
+int AMDSClientMiddleTimePlusCountBeforeAndAfterDataRequest::writeToDataStream(AMDSDataStream *dataStream) const
 {
-	if(!AMDSClientDataRequest::writeToDataStream(dataStream))
-		return false;
+	int errorCode = AMDSClientDataRequest::writeToDataStream(dataStream);
+	if( errorCode != AMDS_CLIENTREQUEST_SUCCESS)
+		return errorCode;
 
 	*dataStream << middleTime();
 	if(dataStream->status() != QDataStream::Ok)
-		return false;
+		return AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_MIDDLE_TIME;
 	*dataStream << countBefore();
 	if(dataStream->status() != QDataStream::Ok)
-		return false;
+		return AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_COUNT_BEFORE;
 	*dataStream << countAfter();
 	if(dataStream->status() != QDataStream::Ok)
-		return false;
+		return AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_COUNT_AFTER;
 
-	return true;
+	return AMDS_CLIENTREQUEST_SUCCESS;
 }
 
-bool AMDSClientMiddleTimePlusCountBeforeAndAfterDataRequest::readFromDataStream(AMDSDataStream *dataStream)
+int AMDSClientMiddleTimePlusCountBeforeAndAfterDataRequest::readFromDataStream(AMDSDataStream *dataStream)
 {
-	if(!AMDSClientDataRequest::readFromDataStream(dataStream))
-		return false;
+	int errorCode = AMDSClientDataRequest::readFromDataStream(dataStream);
+	if( errorCode != AMDS_CLIENTREQUEST_SUCCESS)
+		return errorCode;
 
 	QDateTime readMiddleTime;
 	quint64 countBefore;
@@ -70,17 +72,17 @@ bool AMDSClientMiddleTimePlusCountBeforeAndAfterDataRequest::readFromDataStream(
 
 	*dataStream >> readMiddleTime;
 	if(dataStream->status() != QDataStream::Ok)
-		return false;
+		return AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_MIDDLE_TIME;
 	*dataStream >> countBefore;
 	if(dataStream->status() != QDataStream::Ok)
-		return false;
+		return AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_COUNT_BEFORE;
 	*dataStream >> countAfter;
 	if(dataStream->status() != QDataStream::Ok)
-		return false;
+		return AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_COUNT_AFTER;
 
 	setMiddleTime(readMiddleTime);
 	setCountBefore(countBefore);
 	setCountAfter(countAfter);
 
-	return true;
+	return AMDS_CLIENTREQUEST_SUCCESS;
 }

--- a/source/ClientRequest/AMDSClientMiddleTimePlusCountBeforeAndAfterDataRequest.h
+++ b/source/ClientRequest/AMDSClientMiddleTimePlusCountBeforeAndAfterDataRequest.h
@@ -32,10 +32,10 @@ public:
 	/// Sets the count after for the data request
 	inline void setCountAfter(quint64 count) { countAfter_ = count; }
 
-	/// Writes this AMDSClientRelativeCountPlusCountDataRequest to an AMDSDataStream, returns true if no errors are encountered
-	virtual bool writeToDataStream(AMDSDataStream *dataStream) const;
-	/// Reads this AMDSClientRelativeCountPlusCountDataRequest from the AMDSDataStream, returns true if no errors are encountered
-	virtual bool readFromDataStream(AMDSDataStream *dataStream);
+	/// Writes this AMDSClientRelativeCountPlusCountDataRequest to an AMDSDataStream, returns 0 if no errors are encountered
+	virtual int writeToDataStream(AMDSDataStream *dataStream) const;
+	/// Reads this AMDSClientRelativeCountPlusCountDataRequest from the AMDSDataStream, returns 0 if no errors are encountered
+	virtual int readFromDataStream(AMDSDataStream *dataStream);
 
 protected:
 	/// Middle time for data

--- a/source/ClientRequest/AMDSClientRelativeCountPlusCountDataRequest.cpp
+++ b/source/ClientRequest/AMDSClientRelativeCountPlusCountDataRequest.cpp
@@ -39,38 +39,40 @@ AMDSClientRelativeCountPlusCountDataRequest& AMDSClientRelativeCountPlusCountDat
 	return (*this);
 }
 
-bool AMDSClientRelativeCountPlusCountDataRequest::writeToDataStream(AMDSDataStream *dataStream) const
+int AMDSClientRelativeCountPlusCountDataRequest::writeToDataStream(AMDSDataStream *dataStream) const
 {
-	if(!AMDSClientDataRequest::writeToDataStream(dataStream))
-		return false;
+	int errorCode = AMDSClientDataRequest::writeToDataStream(dataStream);
+	if( errorCode != AMDS_CLIENTREQUEST_SUCCESS)
+		return errorCode;
 
 	*dataStream << relativeCount();
 	if(dataStream->status() != QDataStream::Ok)
-		return false;
+		return AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_RELATIVE_COUNT;
 	*dataStream << count();
 	if(dataStream->status() != QDataStream::Ok)
-		return false;
+		return AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_COUNT;
 
-	return true;
+	return AMDS_CLIENTREQUEST_SUCCESS;
 }
 
-bool AMDSClientRelativeCountPlusCountDataRequest::readFromDataStream(AMDSDataStream *dataStream)
+int AMDSClientRelativeCountPlusCountDataRequest::readFromDataStream(AMDSDataStream *dataStream)
 {
-	if(!AMDSClientDataRequest::readFromDataStream(dataStream))
-		return false;
+	int errorCode = AMDSClientDataRequest::readFromDataStream(dataStream);
+	if( errorCode != AMDS_CLIENTREQUEST_SUCCESS)
+		return errorCode;
 
 	quint64 readRelativeCount;
 	quint64 readCount;
 
 	*dataStream >> readRelativeCount;
 	if(dataStream->status() != QDataStream::Ok)
-		return false;
+		return AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_RELATIVE_COUNT;
 	*dataStream >> readCount;
 	if(dataStream->status() != QDataStream::Ok)
-		return false;
+		return AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_COUNT;
 
 	setRelativeCount(readRelativeCount);
 	setCount(readCount);
 
-	return true;
+	return AMDS_CLIENTREQUEST_SUCCESS;
 }

--- a/source/ClientRequest/AMDSClientRelativeCountPlusCountDataRequest.h
+++ b/source/ClientRequest/AMDSClientRelativeCountPlusCountDataRequest.h
@@ -26,10 +26,10 @@ public:
 	/// set the number of data points after the start time to collect
 	inline void setCount(quint64 count) { count_ = (count==0 ? 1 : count); }
 
-	/// Writes this AMDSClientRelativeCountPlusCountDataRequest to an AMDSDataStream, returns true if no errors are encountered
-	virtual bool writeToDataStream(AMDSDataStream *dataStream) const;
-	/// Reads this AMDSClientRelativeCountPlusCountDataRequest from the AMDSDataStream, returns true if no errors are encountered
-	virtual bool readFromDataStream(AMDSDataStream *dataStream);
+	/// Writes this AMDSClientRelativeCountPlusCountDataRequest to an AMDSDataStream, returns 0 if no errors are encountered
+	virtual int writeToDataStream(AMDSDataStream *dataStream) const;
+	/// Reads this AMDSClientRelativeCountPlusCountDataRequest from the AMDSDataStream, returns 0 if no errors are encountered
+	virtual int readFromDataStream(AMDSDataStream *dataStream);
 
 protected:
 	/// the relative count to start

--- a/source/ClientRequest/AMDSClientRequest.cpp
+++ b/source/ClientRequest/AMDSClientRequest.cpp
@@ -32,22 +32,22 @@ AMDSClientRequest& AMDSClientRequest::operator =(const AMDSClientRequest &other)
 	return (*this);
 }
 
-bool AMDSClientRequest::writeToDataStream(AMDSDataStream *dataStream) const
+int AMDSClientRequest::writeToDataStream(AMDSDataStream *dataStream) const
 {
 	*dataStream << socketKey_;
 	if(dataStream->status() != QDataStream::Ok)
-		return false;
+		return AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_SOCKET_KEY;
 	*dataStream << errorMessage_;
 	if(dataStream->status() != QDataStream::Ok)
-		return false;
+		return AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_ERROR_MESSAGE;
 	*dataStream << (quint8)responseType_;
 	if(dataStream->status() != QDataStream::Ok)
-		return false;
+		return AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_RESPONSE_TYPE;
 
-	return true;
+	return AMDS_CLIENTREQUEST_SUCCESS;
 }
 
-bool AMDSClientRequest::readFromDataStream(AMDSDataStream *dataStream)
+int AMDSClientRequest::readFromDataStream(AMDSDataStream *dataStream)
 {
 	QString readSocketKey;
 	QString readErrorMessage;
@@ -55,18 +55,18 @@ bool AMDSClientRequest::readFromDataStream(AMDSDataStream *dataStream)
 
 	*dataStream >> readSocketKey;
 	if(dataStream->status() != QDataStream::Ok)
-		return false;
+		return AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_STATUS;
 	*dataStream >> readErrorMessage;
 	if(dataStream->status() != QDataStream::Ok)
-		return false;
+		return AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_ERROR_MESSAGE;
 	*dataStream >> readResponseType;
 	if(dataStream->status() != QDataStream::Ok)
-		return false;
+		return AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_RESPONSE_TYPE;
 
 	//NOTE: we won't change the requestType :)
 	setAttributesValues(readSocketKey, readErrorMessage, requestType(), (AMDSClientRequest::ResponseType)readResponseType);
 
-	return true;
+	return AMDS_CLIENTREQUEST_SUCCESS;
 }
 
 void AMDSClientRequest::setAttributesValues(const QString &socketKey, const QString &errorMessage, AMDSClientRequestDefinitions::RequestType requestType, AMDSClientRequest::ResponseType responseType)

--- a/source/ClientRequest/AMDSClientRequest.h
+++ b/source/ClientRequest/AMDSClientRequest.h
@@ -46,10 +46,10 @@ public:
 	/// Sets the repsonse type
 	inline void setResponseType(ResponseType responseType) { responseType_ = responseType; }
 
-	/// Writes this AMDSClientRequest to an AMDSDataStream, returns true if no errors are encountered
-	virtual bool writeToDataStream(AMDSDataStream *dataStream) const;
-	/// Reads this AMDSClientRequest from the AMDSDataStream, returns true if no errors are encountered
-	virtual bool readFromDataStream(AMDSDataStream *dataStream);
+	/// Writes this AMDSClientRequest to an AMDSDataStream, returns 0 if no errors are encountered
+	virtual int writeToDataStream(AMDSDataStream *dataStream) const;
+	/// Reads this AMDSClientRequest from the AMDSDataStream, returns 0 if no errors are encountered
+	virtual int readFromDataStream(AMDSDataStream *dataStream);
 
 	/// validate the message response
 	virtual bool validateResponse() {return true;}

--- a/source/ClientRequest/AMDSClientRequestDefinitions.h
+++ b/source/ClientRequest/AMDSClientRequestDefinitions.h
@@ -1,7 +1,46 @@
 #ifndef AMDSCLIENTREQUESTDEFINITIONS_H
 #define AMDSCLIENTREQUESTDEFINITIONS_H
 
+#include <QString>
+
 namespace AMDSClientRequestDefinitions {
+	#define AMDS_CLIENTREQUEST_SUCCESS 0
+	#define AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_SOCKET_KEY 20100  // 2xxxx error codes for client request
+	#define AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_STATUS 20101  // 2xxxx error codes for client request
+	#define AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_ERROR_MESSAGE 20102
+	#define AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_RESPONSE_TYPE 20103
+	#define AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_BUFFER_NAME 20104
+
+	#define AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_PACKET_STATS_COUNT 20110 // AMDSClientStatisticsRequest
+	#define AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_PACKET_STATS 20111
+
+	#define AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_BUFFER_GROUP_INFO_COUNT 20120 // AMDSClientIntrospectionRequest
+	#define AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_BUFFER_GROUP_INFO 20121
+
+	#define AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_INCLUDE_STATUS 20130 // AMDSClientDataRequest
+	#define AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_INCLUDE_DATA 20131
+	#define AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_UNIFORM_DATA_TYPE 20132
+	#define AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_DATA_COUNT 20133
+	#define AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_DECODE_DATA_TYPE 20134
+	#define AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_DECODE_DATA_TYPE_IN_DATA_HOLDER 20135
+	#define AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_DATA_HOLDER_TYPE 20136
+	#define AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_INSTANTIATE_DATA_HOLDER 20137
+	#define AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_DATA_HOLDER_DATA 20138
+
+	#define AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_START_TIME 20140
+	#define AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_END_TIME 20141
+	#define AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_MIDDLE_TIME 20142
+	#define AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_COUNT 20143
+	#define AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_RELATIVE_COUNT 20144
+	#define AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_COUNT_BEFORE 20145
+	#define AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_COUNT_AFTER 20146
+	#define AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_UPDATE_INTERVAL 20147
+	#define AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_HANDSHAKE_SOCKET_KEY 20148
+
+	enum OperationType{
+		Read = 0,
+		Write = 1
+	};
 	enum RequestType{
 		Introspection = 0,
 		Statistics = 1,
@@ -12,6 +51,104 @@ namespace AMDSClientRequestDefinitions {
 		Continuous = 6,
 		InvalidRequest = 7
 	};
+
+	static QString errorMessage(int errorCode, OperationType operType, RequestType msgType) {
+		QString fieldName;
+
+		switch (errorCode) {
+		case AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_SOCKET_KEY:
+			fieldName = "SocketKey";
+			break;
+		case AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_STATUS:
+			fieldName = "Status";
+			break;
+		case AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_ERROR_MESSAGE:
+			fieldName = "ErrorMessage";
+			break;
+		case AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_RESPONSE_TYPE:
+			fieldName = "ResponseType";
+			break;
+		case AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_BUFFER_NAME:
+			fieldName = "BufferName";
+			break;
+		case AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_PACKET_STATS_COUNT:
+			fieldName = "PacketStatsCount";
+			break;
+		case AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_PACKET_STATS:
+			fieldName = "PacketStats";
+			break;
+
+		case AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_BUFFER_GROUP_INFO_COUNT:
+			fieldName = "BufferGroupInfoCount";
+			break;
+		case AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_BUFFER_GROUP_INFO:
+			fieldName = "BufferGroupInfo";
+			break;
+
+		case AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_INCLUDE_STATUS:
+			fieldName = "IncludeStatus";
+			break;
+		case AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_INCLUDE_DATA:
+			fieldName = "IncludeData";
+			break;
+		case AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_UNIFORM_DATA_TYPE:
+			fieldName = "UniformDataType";
+			break;
+		case AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_DATA_COUNT:
+			fieldName = "DataCount";
+			break;
+		case AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_DECODE_DATA_TYPE:
+			fieldName = "DecodeDataType";
+			break;
+		case AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_DECODE_DATA_TYPE_IN_DATA_HOLDER:
+			fieldName = "DecodeDataTypeInDataHolder";
+			break;
+		case AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_DATA_HOLDER_TYPE:
+			fieldName = "DataHolderType";
+			break;
+		case AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_INSTANTIATE_DATA_HOLDER:
+			fieldName = "InstantiateDataHolder";
+			break;
+		case AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_DATA_HOLDER_DATA:
+			fieldName = "DataHolderData";
+			break;
+
+		case AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_START_TIME:
+			fieldName = "StartTime";
+			break;
+		case AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_END_TIME:
+			fieldName = "EndTime";
+			break;
+		case AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_MIDDLE_TIME:
+			fieldName = "MiddleTime";
+			break;
+		case AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_COUNT:
+			fieldName = "Count";
+			break;
+		case AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_RELATIVE_COUNT:
+			fieldName = "RelativeCount";
+			break;
+		case AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_COUNT_BEFORE:
+			fieldName = "CountBefore";
+			break;
+		case AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_COUNT_AFTER:
+			fieldName = "CountAfter";
+			break;
+		case AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_UPDATE_INTERVAL:
+			fieldName = "UpdateInterval";
+			break;
+		case AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_HANDSHAKE_SOCKET_KEY:
+			fieldName = "HandShakeSocketKey";
+			break;
+		default:
+			fieldName = "Unknown";
+			break;
+		}
+
+		QString operation = (operType == Read ? "read" : "write");
+		QString errMsg = QString("Failed to %1 `%2` for message type %3 ").arg(operation).arg(fieldName).arg(msgType);
+		return errMsg;
+	}
 }
 
 #endif // AMDSCLIENTREQUESTDEFINITIONS_H

--- a/source/ClientRequest/AMDSClientStartTimePlusCountDataRequest.cpp
+++ b/source/ClientRequest/AMDSClientStartTimePlusCountDataRequest.cpp
@@ -38,38 +38,40 @@ AMDSClientStartTimePlusCountDataRequest& AMDSClientStartTimePlusCountDataRequest
 	return (*this);
 }
 
-bool AMDSClientStartTimePlusCountDataRequest::writeToDataStream(AMDSDataStream *dataStream) const
+int AMDSClientStartTimePlusCountDataRequest::writeToDataStream(AMDSDataStream *dataStream) const
 {
-	if(!AMDSClientDataRequest::writeToDataStream(dataStream))
-		return false;
+	int errorCode = AMDSClientDataRequest::writeToDataStream(dataStream);
+	if( errorCode != AMDS_CLIENTREQUEST_SUCCESS)
+		return errorCode;
 
 	*dataStream << startTime();
 	if(dataStream->status() != QDataStream::Ok)
-		return false;
+		return AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_START_TIME;
 	*dataStream << count();
 	if(dataStream->status() != QDataStream::Ok)
-		return false;
+		return AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_COUNT;
 
-	return true;
+	return AMDS_CLIENTREQUEST_SUCCESS;
 }
 
-bool AMDSClientStartTimePlusCountDataRequest::readFromDataStream(AMDSDataStream *dataStream)
+int AMDSClientStartTimePlusCountDataRequest::readFromDataStream(AMDSDataStream *dataStream)
 {
-	if(!AMDSClientDataRequest::readFromDataStream(dataStream))
-		return false;
+	int errorCode = AMDSClientDataRequest::readFromDataStream(dataStream);
+	if( errorCode != AMDS_CLIENTREQUEST_SUCCESS)
+		return errorCode;
 
 	QDateTime readStartTime;
 	quint64 readCount;
 
 	*dataStream >> readStartTime;
 	if(dataStream->status() != QDataStream::Ok)
-		return false;
+		return AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_START_TIME;
 	*dataStream >> readCount;
 	if(dataStream->status() != QDataStream::Ok)
-		return false;
+		return AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_COUNT;
 
 	setStartTime(readStartTime);
 	setCount(readCount);
 
-	return true;
+	return AMDS_CLIENTREQUEST_SUCCESS;
 }

--- a/source/ClientRequest/AMDSClientStartTimePlusCountDataRequest.h
+++ b/source/ClientRequest/AMDSClientStartTimePlusCountDataRequest.h
@@ -28,10 +28,10 @@ public:
 	/// Sets the number of data points after the start time to collect
 	inline void setCount(quint64 count) { count_ = qMax((quint64)1, count) ; }
 
-	/// Writes this AMDSClientStartTimePlusCountDataRequest to an AMDSDataStream, returns true if no errors are encountered
-	virtual bool writeToDataStream(AMDSDataStream *dataStream) const;
-	/// Reads this AMDSClientStartTimePlusCountDataRequest from the AMDSDataStream, returns true if no errors are encountered
-	virtual bool readFromDataStream(AMDSDataStream *dataStream);
+	/// Writes this AMDSClientStartTimePlusCountDataRequest to an AMDSDataStream, returns 0 if no errors are encountered
+	virtual int writeToDataStream(AMDSDataStream *dataStream) const;
+	/// Reads this AMDSClientStartTimePlusCountDataRequest from the AMDSDataStream, returns 0 if no errors are encountered
+	virtual int readFromDataStream(AMDSDataStream *dataStream);
 
 protected:
 	/// Start time for data

--- a/source/ClientRequest/AMDSClientStartTimeToEndTimeDataRequest.cpp
+++ b/source/ClientRequest/AMDSClientStartTimeToEndTimeDataRequest.cpp
@@ -38,38 +38,40 @@ AMDSClientStartTimeToEndTimeDataRequest& AMDSClientStartTimeToEndTimeDataRequest
 	return (*this);
 }
 
-bool AMDSClientStartTimeToEndTimeDataRequest::writeToDataStream(AMDSDataStream *dataStream) const
+int AMDSClientStartTimeToEndTimeDataRequest::writeToDataStream(AMDSDataStream *dataStream) const
 {
-	if(!AMDSClientDataRequest::writeToDataStream(dataStream))
-		return false;
+	int errorCode = AMDSClientDataRequest::writeToDataStream(dataStream);
+	if( errorCode != AMDS_CLIENTREQUEST_SUCCESS)
+		return errorCode;
 
 	*dataStream << startTime();
 	if(dataStream->status() != QDataStream::Ok)
-		return false;
+		return AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_START_TIME;
 	*dataStream << endTime();
 	if(dataStream->status() != QDataStream::Ok)
-		return false;
+		return AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_END_TIME;
 
-	return true;
+	return AMDS_CLIENTREQUEST_SUCCESS;
 }
 
-bool AMDSClientStartTimeToEndTimeDataRequest::readFromDataStream(AMDSDataStream *dataStream)
+int AMDSClientStartTimeToEndTimeDataRequest::readFromDataStream(AMDSDataStream *dataStream)
 {
-	if(!AMDSClientDataRequest::readFromDataStream(dataStream))
-		return false;
+	int errorCode = AMDSClientDataRequest::readFromDataStream(dataStream);
+	if( errorCode != AMDS_CLIENTREQUEST_SUCCESS)
+		return errorCode;
 
 	QDateTime readStartTime;
 	QDateTime readEndTime;
 
 	*dataStream >> readStartTime;
 	if(dataStream->status() != QDataStream::Ok)
-		return false;
+		return AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_START_TIME;
 	*dataStream >> readEndTime;
 	if(dataStream->status() != QDataStream::Ok)
-		return false;
+		return AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_END_TIME;
 
 	setStartTime(readStartTime);
 	setEndTime(readEndTime);
 
-	return true;
+	return AMDS_CLIENTREQUEST_SUCCESS;
 }

--- a/source/ClientRequest/AMDSClientStartTimeToEndTimeDataRequest.h
+++ b/source/ClientRequest/AMDSClientStartTimeToEndTimeDataRequest.h
@@ -28,10 +28,10 @@ public:
 	/// Sets the end time for the data request
 	inline void setEndTime(const QDateTime &endTime) { endTime_ = endTime; }
 
-	/// Writes this AMDSClientRelativeCountPlusCountDataRequest to an AMDSDataStream, returns true if no errors are encountered
-	virtual bool writeToDataStream(AMDSDataStream *dataStream) const;
-	/// Reads this AMDSClientRelativeCountPlusCountDataRequest from the AMDSDataStream, returns true if no errors are encountered
-	virtual bool readFromDataStream(AMDSDataStream *dataStream);
+	/// Writes this AMDSClientRelativeCountPlusCountDataRequest to an AMDSDataStream, returns 0 if no errors are encountered
+	virtual int writeToDataStream(AMDSDataStream *dataStream) const;
+	/// Reads this AMDSClientRelativeCountPlusCountDataRequest from the AMDSDataStream, returns 0 if no errors are encountered
+	virtual int readFromDataStream(AMDSDataStream *dataStream);
 
 protected:
 	/// Start time for data

--- a/source/ClientRequest/AMDSClientStatisticsRequest.cpp
+++ b/source/ClientRequest/AMDSClientStatisticsRequest.cpp
@@ -37,43 +37,45 @@ AMDSClientStatisticsRequest& AMDSClientStatisticsRequest::operator =(const AMDSC
 	return (*this);
 }
 
-bool AMDSClientStatisticsRequest::writeToDataStream(AMDSDataStream *dataStream) const
+int AMDSClientStatisticsRequest::writeToDataStream(AMDSDataStream *dataStream) const
 {
-	if(!AMDSClientRequest::writeToDataStream(dataStream))
-		return false;
+	int errorCode = AMDSClientRequest::writeToDataStream(dataStream);
+	if( errorCode != AMDS_CLIENTREQUEST_SUCCESS)
+		return errorCode;
 
 	*dataStream << (quint32)packetStats_.count();
 	if(dataStream->status() != QDataStream::Ok)
-		return false;
+		return AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_PACKET_STATS_COUNT;
 
 	for(int x = 0, size = packetStats().count(); x < size; x++)
 		dataStream->write(packetStats().at(x));
 
-	return true;
+	return AMDS_CLIENTREQUEST_SUCCESS;
 }
 
-bool AMDSClientStatisticsRequest::readFromDataStream(AMDSDataStream *dataStream)
+int AMDSClientStatisticsRequest::readFromDataStream(AMDSDataStream *dataStream)
 {
-	if(!AMDSClientRequest::readFromDataStream(dataStream))
-		return false;
+	int errorCode = AMDSClientRequest::readFromDataStream(dataStream);
+	if( errorCode != AMDS_CLIENTREQUEST_SUCCESS)
+		return errorCode;
 
 	quint32 readPacketStatsCount;
 	QList<AMDSPacketStats> readPacketStats;
 
 	*dataStream >> readPacketStatsCount;
 	if(dataStream->status() != QDataStream::Ok)
-		return false;
+		return AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_PACKET_STATS_COUNT;
 
 	for(int x = 0, size = readPacketStatsCount; x < size; x++){
 		AMDSPacketStats onePacketStat("Invalid");
 		dataStream->read(onePacketStat);
 		if(onePacketStat.name() == "Invalid")
-			return false;
+			return AMDS_CLIENTREQUEST_FAIL_TO_HANDLE_PACKET_STATS;
 		readPacketStats.append(onePacketStat);
 	}
 
 	packetStats_.append(readPacketStats);
-	return true;
+	return AMDS_CLIENTREQUEST_SUCCESS;
 }
 
 bool AMDSClientStatisticsRequest::validateResponse()

--- a/source/ClientRequest/AMDSClientStatisticsRequest.h
+++ b/source/ClientRequest/AMDSClientStatisticsRequest.h
@@ -25,10 +25,10 @@ public:
 	/// Clears the list of packet stats
 	inline void clearPacketStats() { packetStats_.clear(); }
 
-	/// Writes this AMDSClientStatisticsRequest to an AMDSDataStream, returns true if no errors are encountered
-	virtual bool writeToDataStream(AMDSDataStream *dataStream) const;
-	/// Reads this AMDSClientStatisticsRequest from the AMDSDataStream, returns true if no errors are encountered
-	virtual bool readFromDataStream(AMDSDataStream *dataStream);
+	/// Writes this AMDSClientStatisticsRequest to an AMDSDataStream, returns 0 if no errors are encountered
+	virtual int writeToDataStream(AMDSDataStream *dataStream) const;
+	/// Reads this AMDSClientStatisticsRequest from the AMDSDataStream, returns 0 if no errors are encountered
+	virtual int readFromDataStream(AMDSDataStream *dataStream);
 	/// validate the message response
 	virtual bool validateResponse();
 


### PR DESCRIPTION
https://github.com/acquaman/AcquamanDataServer/issues/60

Added:
 -- error codes for AMDSClientRequest fields
 -- return corresponding error codes for the read/write operation of ClientRequest
 -- print out error messages when error happened
