### PR TITLE
PullRequest for Issue21: Client Interface classes: make request of 5 types

### DIFF
--- a/source/AMDSCentralServer.cpp
+++ b/source/AMDSCentralServer.cpp
@@ -34,7 +34,7 @@ AMDSCentralServer::AMDSCentralServer(QObject *parent) :
 	startTimer();
 }
 
-void AMDSCentralServer::onDataServerErrorHandler(quint8 errorLevel, quint16 errorCode, QString errorMessage)
+void AMDSCentralServer::onDataServerErrorHandler(quint8 errorLevel, quint16 errorCode, const QString &errorMessage)
 {
 	switch(errorLevel) {
 	case AMDSErrorReport::Serious:

--- a/source/AMDSCentralServer.cpp
+++ b/source/AMDSCentralServer.cpp
@@ -55,7 +55,7 @@ void AMDSCentralServer::onDataServerClientRequestReady(AMDSClientRequest *client
 				QMap<QString, AMDSThreadedBufferGroup*>::const_iterator i = bufferGroups_.constBegin();
 				while (i != bufferGroups_.constEnd()) {
 					AMDSBufferGroupInfo oneInfo = i.value()->bufferGroupInfo();
-					AMDSErrorMon::information(this, AMDS_SERVER_INFO_BUFFER_DEF, QString("%1 definition is %2 %3 %4 %5 %6 %7").arg(i.key()).arg(oneInfo.name()).arg(oneInfo.description()).arg(oneInfo.units()).arg(oneInfo.size().toString()).arg(oneInfo.flattenEnabled()?"true":"false").arg(oneInfo.flattenMethod()));
+					AMDSErrorMon::information(this, AMDS_SERVER_INFO_BUFFER_DEF, QString("%1 definition is %2 %3 %4 %5 %6 %7").arg(i.key()).arg(oneInfo.name()).arg(oneInfo.description()).arg(oneInfo.units()).arg(oneInfo.size().toString()).arg(oneInfo.isFlattenEnabled()?"true":"false").arg(oneInfo.flattenMethod()));
 					clientIntrospectionRequest->appendBufferGroupInfo(oneInfo);
 					++i;
 				}
@@ -136,19 +136,19 @@ void AMDSCentralServer::initializeBufferGroup(quint64 maxCountSize)
 	QList<AMDSAxisInfo> mcpBufferGroupAxes;
 	mcpBufferGroupAxes << AMDSAxisInfo("X", 1024, "X Axis", "pixel");
 	mcpBufferGroupAxes << AMDSAxisInfo("Y", 512, "Y Axis", "pixel");
-	AMDSBufferGroupInfo mcpBufferGroupInfo("AFakeMCP", "Fake MCP Image", "Counts", false, AMDSBufferGroupInfo::NoFlatten, mcpBufferGroupAxes);
+	AMDSBufferGroupInfo mcpBufferGroupInfo("AFakeMCP", "Fake MCP Image", "Counts", AMDSBufferGroupInfo::NoFlatten, mcpBufferGroupAxes);
 	AMDSBufferGroup *mcpBufferGroup = new AMDSBufferGroup(mcpBufferGroupInfo, maxCountSize);
 	AMDSThreadedBufferGroup *mcpThreadedBufferGroup = new AMDSThreadedBufferGroup(mcpBufferGroup);
 	bufferGroups_.insert(mcpThreadedBufferGroup->bufferGroupInfo().name(), mcpThreadedBufferGroup);
 
 	QList<AMDSAxisInfo> amptek1BufferGroupAxes;
 	amptek1BufferGroupAxes << AMDSAxisInfo("Energy", 1024, "Energy Axis", "eV");
-	AMDSBufferGroupInfo amptek1BufferGroupInfo("Amptek1", "Amptek 1", "Counts", false, AMDSBufferGroupInfo::NoFlatten, amptek1BufferGroupAxes);
+	AMDSBufferGroupInfo amptek1BufferGroupInfo("Amptek1", "Amptek 1", "Counts", AMDSBufferGroupInfo::NoFlatten, amptek1BufferGroupAxes);
 	amptek1BufferGroup_ = new AMDSBufferGroup(amptek1BufferGroupInfo, maxCountSize);
 	AMDSThreadedBufferGroup *amptek1ThreadedBufferGroup = new AMDSThreadedBufferGroup(amptek1BufferGroup_);
 	bufferGroups_.insert(amptek1ThreadedBufferGroup->bufferGroupInfo().name(), amptek1ThreadedBufferGroup);
 
-	AMDSBufferGroupInfo energyBufferGroupInfo("Energy", "SGM Beamline Energy", "eV", true, AMDSBufferGroupInfo::Average);
+	AMDSBufferGroupInfo energyBufferGroupInfo("Energy", "SGM Beamline Energy", "eV", AMDSBufferGroupInfo::Average);
 	energyBufferGroup_ = new AMDSBufferGroup(energyBufferGroupInfo, maxCountSize);
 	AMDSThreadedBufferGroup *energyThreadedBufferGroup = new AMDSThreadedBufferGroup(energyBufferGroup_);
 	bufferGroups_.insert(energyThreadedBufferGroup->bufferGroupInfo().name(), energyThreadedBufferGroup);

--- a/source/AMDSCentralServer.cpp
+++ b/source/AMDSCentralServer.cpp
@@ -143,7 +143,7 @@ void AMDSCentralServer::initializeBufferGroup(quint64 maxCountSize)
 
 	QList<AMDSAxisInfo> amptek1BufferGroupAxes;
 	amptek1BufferGroupAxes << AMDSAxisInfo("Energy", 1024, "Energy Axis", "eV");
-	AMDSBufferGroupInfo amptek1BufferGroupInfo("Amptek1", "Amptek 1", "Counts", AMDSBufferGroupInfo::NoFlatten, amptek1BufferGroupAxes);
+	AMDSBufferGroupInfo amptek1BufferGroupInfo("Amptek1", "Amptek 1", "Counts", AMDSBufferGroupInfo::Summary, amptek1BufferGroupAxes);
 	amptek1BufferGroup_ = new AMDSBufferGroup(amptek1BufferGroupInfo, maxCountSize);
 	AMDSThreadedBufferGroup *amptek1ThreadedBufferGroup = new AMDSThreadedBufferGroup(amptek1BufferGroup_);
 	bufferGroups_.insert(amptek1ThreadedBufferGroup->bufferGroupInfo().name(), amptek1ThreadedBufferGroup);

--- a/source/AMDSCentralServer.h
+++ b/source/AMDSCentralServer.h
@@ -29,7 +29,7 @@ signals:
 
 protected slots:
 	/// slot to handle the errors information from the TCP Data server
-	void onDataServerErrorHandler(quint8 errorLevel, quint16 errorCode, QString errorMessage);
+	void onDataServerErrorHandler(quint8 errorLevel, quint16 errorCode, const QString &errorMessage);
 	/// slot to handle the client request from the TCP Data server
 	void onDataServerClientRequestReady(AMDSClientRequest *clientRequest);
 

--- a/source/AMDSClientUi.cpp
+++ b/source/AMDSClientUi.cpp
@@ -179,7 +179,7 @@ void AMDSClientUi::onNetworkSessionOpened()
 	enableRequestDataButton();
 }
 
-void AMDSClientUi::onNewServerConnected(QString serverIdentifier)
+void AMDSClientUi::onNewServerConnected(const QString &serverIdentifier)
 {
 	if (activeServerComboBox_->findText(serverIdentifier) == -1) {
 		activeServerComboBox_->addItem(serverIdentifier);
@@ -219,7 +219,7 @@ void AMDSClientUi::onRequestDataReady(AMDSClientRequest* clientRequest)
 	}
 }
 
-void AMDSClientUi::onServerError(int errorCode, bool removeServer, QString serverIdentifier, QString errorMessage)
+void AMDSClientUi::onServerError(int errorCode, bool removeServer, const QString &serverIdentifier, const QString &errorMessage)
 {
 	if (serverIdentifier.length() > 0) {
 		if (removeServer)
@@ -234,7 +234,7 @@ void AMDSClientUi::onServerError(int errorCode, bool removeServer, QString serve
 }
 
 /// ============= SLOTS to handle UI component signals ===============
-void AMDSClientUi::onActiveServerChanged(QString serverIdentifier)
+void AMDSClientUi::onActiveServerChanged(const QString &serverIdentifier)
 {
 	QStringList bufferNames = clientAppController_->getBufferNamesByServer(serverIdentifier);
 	resetBufferListView(bufferNames);
@@ -242,7 +242,7 @@ void AMDSClientUi::onActiveServerChanged(QString serverIdentifier)
 	resetActiveContinuousConnection(serverIdentifier);
 }
 
-void AMDSClientUi::onRequestTypeChanged(QString requestType)
+void AMDSClientUi::onRequestTypeChanged(const QString &requestType)
 {
 	if (requestType == "Continuous") {
 		bufferNameListView_->setSelectionMode(QAbstractItemView::MultiSelection);
@@ -325,14 +325,14 @@ void AMDSClientUi::sendClientRequest()
 	}
 }
 
-void AMDSClientUi::resetBufferListView(QStringList &bufferNames)
+void AMDSClientUi::resetBufferListView(const QStringList &bufferNames)
 {
 	QStringListModel *bufferNamesModel = new QStringListModel(this);
 	bufferNamesModel->setStringList(bufferNames);
 	bufferNameListView_->setModel(bufferNamesModel);
 }
 
-void AMDSClientUi::resetActiveContinuousConnection(QString serverIdentifier)
+void AMDSClientUi::resetActiveContinuousConnection(const QString &serverIdentifier)
 {
 	QStringList activeContinuousClientRequestKeys = clientAppController_->getActiveSocketKeysByServer(serverIdentifier);
 

--- a/source/AMDSClientUi.cpp
+++ b/source/AMDSClientUi.cpp
@@ -148,6 +148,7 @@ AMDSClientUi::~AMDSClientUi()
 	disconnect(clientAppController_, SIGNAL(requestDataReady(AMDSClientRequest*)), this, SLOT(onRequestDataReady(AMDSClientRequest*)));
 
 	clientAppController_->deleteLater();
+	clientAppController_ = 0;
 }
 
 void AMDSClientUi::connectToServer()

--- a/source/AMDSClientUi.cpp
+++ b/source/AMDSClientUi.cpp
@@ -338,11 +338,10 @@ void AMDSClientUi::resetActiveContinuousConnection(const QString &serverIdentifi
 
 	bool updateActiveContiuousConnectionComboBox = false;
 	if (activeContinuousClientRequestKeys.length() == activeContinuousConnectionComboBox_->count()) {
-		for (int i = 0; i < activeContinuousConnectionComboBox_->count(); i++) {
+		for (int i = 0; (i < activeContinuousConnectionComboBox_->count()) && (!updateActiveContiuousConnectionComboBox); i++) {
 			QString itemText = activeContinuousConnectionComboBox_->itemText(i);
 			if (!activeContinuousClientRequestKeys.contains(itemText)) {
 				updateActiveContiuousConnectionComboBox = true;
-				break;
 			}
 		}
 	} else {

--- a/source/AMDSClientUi.h
+++ b/source/AMDSClientUi.h
@@ -42,7 +42,7 @@ private slots:
 	/// slot to handle the signal of request data ready
 	void onRequestDataReady(AMDSClientRequest* clientRequest);
 	/// slot to handle the signal of socketEror
-	void onServerError(int errorCode, QString serverIdentifier, QString errorMessage);
+	void onServerError(int errorCode, bool removeServer, QString serverIdentifier, QString errorMessage);
 
 	/// ============= SLOTS to handle UI component signals ===============
 	/// slot to handle the switch signal among connected servers (to refresh the buffer names and the active connections with that server)

--- a/source/AMDSClientUi.h
+++ b/source/AMDSClientUi.h
@@ -38,17 +38,17 @@ private slots:
 	void onNetworkSessionOpened();
 
 	/// slot to handle the signal of newServerConnected (add the serverIdentifier to the combox and update the ui displays -- buffernames and active connections)
-	void onNewServerConnected(QString serverIdentifier);
+	void onNewServerConnected(const QString &serverIdentifier);
 	/// slot to handle the signal of request data ready
 	void onRequestDataReady(AMDSClientRequest* clientRequest);
 	/// slot to handle the signal of socketEror
-	void onServerError(int errorCode, bool removeServer, QString serverIdentifier, QString errorMessage);
+	void onServerError(int errorCode, bool removeServer, const QString &serverIdentifier, const QString &errorMessage);
 
 	/// ============= SLOTS to handle UI component signals ===============
 	/// slot to handle the switch signal among connected servers (to refresh the buffer names and the active connections with that server)
-	void onActiveServerChanged(QString serverIdentifier);
+	void onActiveServerChanged(const QString &serverIdentifier);
 	/// slot to handle the switch singal among request types (to change the selection mode of the buffer names: multi selection or signal selection)
-	void onRequestTypeChanged(QString requestType);
+	void onRequestTypeChanged(const QString &requestType);
 	/// slot to check whether we should enable the button to send client request
 	void enableRequestDataButton();
 	/// slot to send client request to the server
@@ -56,9 +56,9 @@ private slots:
 
 private:
 	/// slot to reset the buffer list view
-	void resetBufferListView(QStringList &bufferNames);
+	void resetBufferListView(const QStringList &bufferNames);
 	/// slot to reset the acitve continuous connection combox
-	void resetActiveContinuousConnection(QString serverIdentifier="");
+	void resetActiveContinuousConnection(const QString &serverIdentifier="");
 
 private:
 	/// ==== server section ====

--- a/source/AMDSMain.cpp
+++ b/source/AMDSMain.cpp
@@ -2,23 +2,24 @@
 
 #include <QStringList>
 #include <QRegExp>
-#include <QDebug>
 #include <QSettings>
 
 #include "source/AMDSCentralServer.h"
 #include "source/ClientRequest/AMDSClientRequestSupport.h"
 #include "source/DataElement/AMDSEventDataSupport.h"
 #include "source/DataHolder/AMDSDataHolderSupport.h"
+#include "source/util/AMDSErrorMonitor.h"
 
 /*
  * Print the usage of the application
  */
 void printUsage()
 {
-	qDebug() << "\nUsages:" << "\n"
-			 << "	AcquamanDataServer --intf=[interface name] [--port=[portnumber]]\n"
-			 << "	AcquamanDataServer --help\n"
-			 << "\n";
+	QString usage = "\n\nUsages:\n"
+			 "\tAcquamanDataServer --intf=[interface name] [--port=[portnumber]]\n"
+			 "\tAcquamanDataServer --help\n"
+			 "\n";
+	AMDSErrorMon::information(0, 0, usage);
 }
 
 /*
@@ -67,7 +68,7 @@ int main(int argc, char *argv[])
 	}
 
 	if (interfaceType == 0) {
-		qDebug() << "\nERROR: Missing or invalid interface argument. \n";
+		AMDSErrorMon::error(0, 0, "\nERROR: Missing or invalid interface argument. \n");
 		printUsage();
 	} else {
 		initializeAppSettings(interfaceType, port);

--- a/source/ClientRequest/AMDSClientContinuousDataRequest.cpp
+++ b/source/ClientRequest/AMDSClientContinuousDataRequest.cpp
@@ -95,7 +95,7 @@ bool AMDSClientContinuousDataRequest::isExpired()
 	return timeSpanInSecond > 60;
 }
 
-void AMDSClientContinuousDataRequest::setAttributesValues(bool includeStatusData, bool flattenResultData, QStringList &bufferNames, quint64 updateInterval, QString &handShakeSocketKey)
+void AMDSClientContinuousDataRequest::setAttributesValues(bool includeStatusData, bool flattenResultData, const QStringList &bufferNames, quint64 updateInterval, const QString &handShakeSocketKey)
 {
 	setIncludeStatusData(includeStatusData);
 	setFlattenResultData(flattenResultData);

--- a/source/ClientRequest/AMDSClientContinuousDataRequest.h
+++ b/source/ClientRequest/AMDSClientContinuousDataRequest.h
@@ -41,7 +41,7 @@ public:
 	inline bool isHandShakingMessage() { return handShakeSocketKey_.length() > 0; }
 
 	/// Returns the buffer data request message
-	inline AMDSClientContinuousDataRequest *bufferDataRequest(QString bufferName) { return bufferDataRequestList_.value(bufferName); }
+	inline AMDSClientContinuousDataRequest *bufferDataRequest(const QString &bufferName) { return bufferDataRequestList_.value(bufferName); }
 
 	/// Returns whether message expired (didn't receive handshake in a given time interval
 	bool isExpired();
@@ -60,7 +60,7 @@ public:
 	inline void setHandShakeTime(const QDateTime &handShakeTime) { lastHandShakeTime_ = handShakeTime; }
 
 	/// Sets the values of all the data attributes of client request
-	void setAttributesValues(bool includeStatusData, bool flattenResultData, QStringList &bufferNames, quint64 updateInterval, QString &handShakeSocketKey);
+	void setAttributesValues(bool includeStatusData, bool flattenResultData, const QStringList &bufferNames, quint64 updateInterval, const QString &handShakeSocketKey);
 
 	/// Writes this AMDSClientContinuousRequest to an AMDSDataStream, returns 0 if no errors are encountered
 	virtual int writeToDataStream(AMDSDataStream *dataStream) const;

--- a/source/ClientRequest/AMDSClientDataRequest.cpp
+++ b/source/ClientRequest/AMDSClientDataRequest.cpp
@@ -27,6 +27,7 @@ AMDSClientDataRequest::AMDSClientDataRequest(const QString &socketKey, const QSt
 
 AMDSClientDataRequest::~AMDSClientDataRequest()
 {
+	clearData();
 }
 
 AMDSClientDataRequest::AMDSClientDataRequest(const AMDSClientDataRequest &other) :
@@ -49,9 +50,25 @@ AMDSClientDataRequest& AMDSClientDataRequest::operator =(const AMDSClientDataReq
 		uniformDataType_ = other.uniformDataType();
 		clearData();
 		for(int x = 0, size = other.data().count(); x < size; x++)
-			appendData(other.data().at(x));
+			copyAndAppendData(other.data().at(x));
 	}
 	return (*this);
+}
+
+void AMDSClientDataRequest::copyAndAppendData(AMDSDataHolder *dataHolder)
+{
+	AMDSDataHolder *cloneDataHolder = AMDSDataHolderSupport::instantiateDataHolderFromInstance(dataHolder);
+	(*cloneDataHolder) = (*dataHolder);
+
+	data_.append(cloneDataHolder);
+}
+
+void AMDSClientDataRequest::clearData()
+{
+	foreach(AMDSDataHolder *dataHolder, data_) {
+		dataHolder->deleteLater();
+	}
+	data_.clear();
 }
 
 int AMDSClientDataRequest::writeToDataStream(AMDSDataStream *dataStream) const

--- a/source/ClientRequest/AMDSClientDataRequest.cpp
+++ b/source/ClientRequest/AMDSClientDataRequest.cpp
@@ -213,17 +213,25 @@ bool AMDSClientDataRequest::validateResponse()
 	if(responseType() == AMDSClientRequest::Error) {
 		AMDSErrorMon::alert(this, AMDS_CLIENTREQUEST_ERR_FAILED_TO_RETRIEVE_DATA, QString("(msg %1 --- %2) Failed to retrieve data. Error: %3").arg(socketKey()).arg(bufferName()).arg(errorMessage()));
 		noError = false;
-	} else {
-		if (data().count() == 0)
-			AMDSErrorMon::information(this, AMDS_CLIENTREQUEST_INFO_REQUEST_DATA, QString("(msg %1 --- %2) No data for this message yet!").arg(socketKey()).arg(bufferName()));
-		else {
-			for(int x = 0, size = data().count(); x < size; x++){
-				AMDSFlatArray oneFlatArray = AMDSFlatArray(uniformDataType(), bufferGroupInfo().spanSize());
-				data().at(x)->data(&oneFlatArray);
-				AMDSErrorMon::information(this, AMDS_CLIENTREQUEST_INFO_REQUEST_DATA, QString("(msg %1 --- %2) Data at %3 - %4").arg(socketKey()).arg(bufferName()).arg(x).arg(oneFlatArray.printData()));
-			}
-		}
 	}
 
 	return noError;
 }
+
+QString AMDSClientDataRequest::toString()
+{
+	QString messageData = QString("Data of Data message (%1 -- %2):").arg(socketKey()).arg(bufferName());
+
+	if (data().count() == 0)
+		messageData = QString("%1\n\tNo data for this message yet").arg(messageData);
+	else {
+		for(int x = 0, size = data().count(); x < size; x++){
+			AMDSFlatArray oneFlatArray = AMDSFlatArray(uniformDataType(), bufferGroupInfo().spanSize());
+			data().at(x)->data(&oneFlatArray);
+			messageData = QString("%1\n\tData at %2 - %3").arg(messageData).arg(x).arg(oneFlatArray.printData());
+		}
+	}
+
+	return messageData;
+}
+

--- a/source/ClientRequest/AMDSClientDataRequest.cpp
+++ b/source/ClientRequest/AMDSClientDataRequest.cpp
@@ -218,7 +218,7 @@ bool AMDSClientDataRequest::validateResponse()
 	return noError;
 }
 
-QString AMDSClientDataRequest::toString()
+QString AMDSClientDataRequest::toString() const
 {
 	QString messageData = QString("Data of Data message (%1 -- %2):").arg(socketKey()).arg(bufferName());
 

--- a/source/ClientRequest/AMDSClientDataRequest.h
+++ b/source/ClientRequest/AMDSClientDataRequest.h
@@ -58,7 +58,7 @@ public:
 	/// validate the message response
 	virtual bool validateResponse();
 	/// implement the function to return a data string of the message
-	virtual QString toString();
+	virtual QString toString() const;
 
 protected:
 	/// The string identifier for the buffer data is being request from or received from

--- a/source/ClientRequest/AMDSClientDataRequest.h
+++ b/source/ClientRequest/AMDSClientDataRequest.h
@@ -54,8 +54,11 @@ public:
 	virtual int writeToDataStream(AMDSDataStream *dataStream) const;
 	/// Reads this AMDSClientDataRequest from the AMDSDataStream, returns 0 if no errors are encountered
 	virtual int readFromDataStream(AMDSDataStream *dataStream);
+
 	/// validate the message response
 	virtual bool validateResponse();
+	/// implement the function to return a data string of the message
+	virtual QString toString();
 
 protected:
 	/// The string identifier for the buffer data is being request from or received from

--- a/source/ClientRequest/AMDSClientDataRequest.h
+++ b/source/ClientRequest/AMDSClientDataRequest.h
@@ -3,8 +3,10 @@
 
 #include "source/ClientRequest/AMDSClientRequest.h"
 #include "source/DataElement/AMDSDataTypeDefinitions.h"
+#include "source/DataHolder/AMDSDataHolder.h"
+#include "source/DataHolder/AMDSDataHolderSupport.h"
 
-class AMDSDataHolder;
+//class AMDSDataHolder;
 
 class AMDSClientDataRequest : public AMDSClientRequest
 {
@@ -46,9 +48,9 @@ public:
 	/// Sets the uniform data type
 	inline void setUniformDataType(AMDSDataTypeDefinitions::DataType uniformDataType) { uniformDataType_ = uniformDataType; }
 	/// Adds some data to the list of data holders
-	inline void appendData(AMDSDataHolder *dataHolder) { data_.append(dataHolder); }
+	void copyAndAppendData(AMDSDataHolder *dataHolder) ;
 	/// Clears the list of data holders
-	inline void clearData() { data_.clear(); }
+	void clearData();
 
 	/// Writes this AMDSClienDatatRequest to an AMDSDataStream, returns 0 if no errors are encountered
 	virtual int writeToDataStream(AMDSDataStream *dataStream) const;

--- a/source/ClientRequest/AMDSClientIntrospectionRequest.cpp
+++ b/source/ClientRequest/AMDSClientIntrospectionRequest.cpp
@@ -105,16 +105,13 @@ int AMDSClientIntrospectionRequest::readFromDataStream(AMDSDataStream *dataStrea
 	return AMDS_CLIENTREQUEST_SUCCESS;
 }
 
-bool AMDSClientIntrospectionRequest::validateResponse()
+QString AMDSClientIntrospectionRequest::toString()
 {
+	QString messageData = QString("Data of Introspection message (%1):").arg(socketKey());
 	for(int y = 0, ySize = bufferGroupInfos_.count(); y < ySize; y++){
 		AMDSBufferGroupInfo bufferGroupInfo = bufferGroupInfos_.at(y);
-		AMDSErrorMon::information(this, AMDS_CLIENTREQUEST_INFO_REQUEST_DATA, QString("%1 %2 %3 %4 %5 %6 %7").arg(bufferGroupInfo.name()).arg(bufferGroupInfo.description()).arg(bufferGroupInfo.units()).arg(bufferGroupInfo.rank()).arg(bufferGroupInfo.size().toString()).arg(bufferGroupInfo.flattenEnabled()?"true":"false").arg(bufferGroupInfo.flattenMethod()));
-		for(int x = 0, size = bufferGroupInfo.axes().count(); x < size; x++){
-			AMDSAxisInfo axisInfo = bufferGroupInfo.axes().at(x);
-			AMDSErrorMon::information(this, AMDS_CLIENTREQUEST_INFO_REQUEST_DATA, QString("\tAxis info at %1 %2 %3 %4 %5 %6 %7 %8").arg(x).arg(axisInfo.name()).arg(axisInfo.description()).arg(axisInfo.units()).arg(axisInfo.size()).arg(axisInfo.isUniform()).arg(axisInfo.start()).arg(axisInfo.increment()));
-		}
+		messageData = QString("%1\n%2").arg(messageData).arg(bufferGroupInfo.toString());
 	}
 
-	return true;
+	return messageData;
 }

--- a/source/ClientRequest/AMDSClientIntrospectionRequest.cpp
+++ b/source/ClientRequest/AMDSClientIntrospectionRequest.cpp
@@ -105,7 +105,7 @@ int AMDSClientIntrospectionRequest::readFromDataStream(AMDSDataStream *dataStrea
 	return AMDS_CLIENTREQUEST_SUCCESS;
 }
 
-QString AMDSClientIntrospectionRequest::toString()
+QString AMDSClientIntrospectionRequest::toString() const
 {
 	QString messageData = QString("Data of Introspection message (%1):").arg(socketKey());
 	for(int y = 0, ySize = bufferGroupInfos_.count(); y < ySize; y++){

--- a/source/ClientRequest/AMDSClientIntrospectionRequest.h
+++ b/source/ClientRequest/AMDSClientIntrospectionRequest.h
@@ -44,7 +44,7 @@ public:
 	virtual int readFromDataStream(AMDSDataStream *dataStream);
 
 	/// implement the function to return a data string of the message
-	virtual QString toString();
+	virtual QString toString() const;
 
 protected:
 	/// The string identifier for the buffer or buffers being introspected

--- a/source/ClientRequest/AMDSClientIntrospectionRequest.h
+++ b/source/ClientRequest/AMDSClientIntrospectionRequest.h
@@ -42,8 +42,9 @@ public:
 	virtual int writeToDataStream(AMDSDataStream *dataStream) const;
 	/// Reads this AMDSClientIntrospectionRequest from the AMDSDataStream, returns 0 if no errors are encountered
 	virtual int readFromDataStream(AMDSDataStream *dataStream);
-	/// validate the message response
-	virtual bool validateResponse();
+
+	/// implement the function to return a data string of the message
+	virtual QString toString();
 
 protected:
 	/// The string identifier for the buffer or buffers being introspected

--- a/source/ClientRequest/AMDSClientMiddleTimePlusCountBeforeAndAfterDataRequest.cpp
+++ b/source/ClientRequest/AMDSClientMiddleTimePlusCountBeforeAndAfterDataRequest.cpp
@@ -41,7 +41,7 @@ AMDSClientMiddleTimePlusCountBeforeAndAfterDataRequest& AMDSClientMiddleTimePlus
 	return (*this);
 }
 
-void AMDSClientMiddleTimePlusCountBeforeAndAfterDataRequest::setAttributesValues(QString &bufferName, bool includeStatusData, bool flattenResultData, QDateTime &middleTime, quint64 countBefore, quint64 countAfter)
+void AMDSClientMiddleTimePlusCountBeforeAndAfterDataRequest::setAttributesValues(const QString &bufferName, bool includeStatusData, bool flattenResultData, const QDateTime &middleTime, quint64 countBefore, quint64 countAfter)
 {
 	setBufferName(bufferName);
 	setIncludeStatusData(includeStatusData);

--- a/source/ClientRequest/AMDSClientMiddleTimePlusCountBeforeAndAfterDataRequest.h
+++ b/source/ClientRequest/AMDSClientMiddleTimePlusCountBeforeAndAfterDataRequest.h
@@ -33,7 +33,7 @@ public:
 	inline void setCountAfter(quint64 count) { countAfter_ = count; }
 
 	/// Sets the values of all the data attributes of client request
-	void setAttributesValues(QString &bufferName, bool includeStatusData, bool flattenResultData, QDateTime &MiddleTime, quint64 countBefore, quint64 countAfter);
+	void setAttributesValues(const QString &bufferName, bool includeStatusData, bool flattenResultData, const QDateTime &MiddleTime, quint64 countBefore, quint64 countAfter);
 
 	/// Writes this AMDSClientRelativeCountPlusCountDataRequest to an AMDSDataStream, returns 0 if no errors are encountered
 	virtual int writeToDataStream(AMDSDataStream *dataStream) const;

--- a/source/ClientRequest/AMDSClientRelativeCountPlusCountDataRequest.cpp
+++ b/source/ClientRequest/AMDSClientRelativeCountPlusCountDataRequest.cpp
@@ -39,7 +39,7 @@ AMDSClientRelativeCountPlusCountDataRequest& AMDSClientRelativeCountPlusCountDat
 	return (*this);
 }
 
-void AMDSClientRelativeCountPlusCountDataRequest::setAttributesValues(QString &bufferName, bool includeStatusData, bool flattenResultData, quint64 relativeCount, quint64 count) {
+void AMDSClientRelativeCountPlusCountDataRequest::setAttributesValues(const QString &bufferName, bool includeStatusData, bool flattenResultData, quint64 relativeCount, quint64 count) {
 	setBufferName(bufferName);
 	setIncludeStatusData(includeStatusData);
 	setFlattenResultData(flattenResultData);

--- a/source/ClientRequest/AMDSClientRelativeCountPlusCountDataRequest.h
+++ b/source/ClientRequest/AMDSClientRelativeCountPlusCountDataRequest.h
@@ -27,7 +27,7 @@ public:
 	inline void setCount(quint64 count) { count_ = (count==0 ? 1 : count); }
 
 	/// Sets the values of all the data attributes of client request
-	void setAttributesValues(QString &bufferName, bool includeStatusData, bool flattenResultData, quint64 relativeCount, quint64 count);
+	void setAttributesValues(const QString &bufferName, bool includeStatusData, bool flattenResultData, quint64 relativeCount, quint64 count);
 	/// Writes this AMDSClientRelativeCountPlusCountDataRequest to an AMDSDataStream, returns 0 if no errors are encountered
 	virtual int writeToDataStream(AMDSDataStream *dataStream) const;
 	/// Reads this AMDSClientRelativeCountPlusCountDataRequest from the AMDSDataStream, returns 0 if no errors are encountered

--- a/source/ClientRequest/AMDSClientRequest.cpp
+++ b/source/ClientRequest/AMDSClientRequest.cpp
@@ -1,6 +1,7 @@
 #include "source/ClientRequest/AMDSClientRequest.h"
 
 #include "source/Connection/AMDSDataStream.h"
+#include "source/util/AMDSErrorMonitor.h"
 
 AMDSClientRequest::AMDSClientRequest(QObject *parent) :
 	QObject(parent)
@@ -76,6 +77,11 @@ int AMDSClientRequest::readFromDataStream(AMDSDataStream *dataStream)
 	setBaseAttributesValues(readSocketKey, readErrorMessage, requestType(), (AMDSClientRequest::ResponseType)readResponseType);
 
 	return AMDS_CLIENTREQUEST_SUCCESS;
+}
+
+void AMDSClientRequest::printData()
+{
+	AMDSErrorMon::information(this, AMDS_CLIENTREQUEST_INFO_REQUEST_DATA, toString());
 }
 
 void AMDSClientRequest::setBaseAttributesValues(const QString &socketKey, const QString &errorMessage, AMDSClientRequestDefinitions::RequestType requestType, AMDSClientRequest::ResponseType responseType)

--- a/source/ClientRequest/AMDSClientRequest.h
+++ b/source/ClientRequest/AMDSClientRequest.h
@@ -60,8 +60,12 @@ public:
 	/// Reads this AMDSClientRequest from the AMDSDataStream, returns 0 if no errors are encountered
 	virtual int readFromDataStream(AMDSDataStream *dataStream);
 
+	/// print out the message data
+	void printData();
 	/// validate the message response
 	virtual bool validateResponse() {return true;}
+	/// pure virtual to return a data string of the message
+	virtual QString toString() = 0;
 
 private:
 	/// To set the values of all the attributes

--- a/source/ClientRequest/AMDSClientRequest.h
+++ b/source/ClientRequest/AMDSClientRequest.h
@@ -65,7 +65,7 @@ public:
 	/// validate the message response
 	virtual bool validateResponse() {return true;}
 	/// pure virtual to return a data string of the message
-	virtual QString toString() = 0;
+	virtual QString toString() const = 0;
 
 private:
 	/// To set the values of all the attributes

--- a/source/ClientRequest/AMDSClientStartTimePlusCountDataRequest.cpp
+++ b/source/ClientRequest/AMDSClientStartTimePlusCountDataRequest.cpp
@@ -38,7 +38,7 @@ AMDSClientStartTimePlusCountDataRequest& AMDSClientStartTimePlusCountDataRequest
 	return (*this);
 }
 
-void AMDSClientStartTimePlusCountDataRequest::setAttributesValues(QString &bufferName, bool includeStatusData, bool flattenResultData, QDateTime &startTime, quint64 count) {
+void AMDSClientStartTimePlusCountDataRequest::setAttributesValues(const QString &bufferName, bool includeStatusData, bool flattenResultData, const QDateTime &startTime, quint64 count) {
 	setBufferName(bufferName);
 	setIncludeStatusData(includeStatusData);
 	setFlattenResultData(flattenResultData);

--- a/source/ClientRequest/AMDSClientStartTimePlusCountDataRequest.h
+++ b/source/ClientRequest/AMDSClientStartTimePlusCountDataRequest.h
@@ -28,7 +28,7 @@ public:
 	/// Sets the number of data points after the start time to collect
 	inline void setCount(quint64 count) { count_ = qMax((quint64)1, count) ; }
 	/// Sets the values of all the data attributes of client request
-	void setAttributesValues(QString &bufferName, bool includeStatusData, bool flattenResultData, QDateTime &startTime, quint64 count);
+	void setAttributesValues(const QString &bufferName, bool includeStatusData, bool flattenResultData, const QDateTime &startTime, quint64 count);
 
 	/// Writes this AMDSClientStartTimePlusCountDataRequest to an AMDSDataStream, returns 0 if no errors are encountered
 	virtual int writeToDataStream(AMDSDataStream *dataStream) const;

--- a/source/ClientRequest/AMDSClientStartTimeToEndTimeDataRequest.cpp
+++ b/source/ClientRequest/AMDSClientStartTimeToEndTimeDataRequest.cpp
@@ -38,7 +38,7 @@ AMDSClientStartTimeToEndTimeDataRequest& AMDSClientStartTimeToEndTimeDataRequest
 	return (*this);
 }
 
-void AMDSClientStartTimeToEndTimeDataRequest::setAttributesValues(QString &bufferName, bool includeStatusData, bool flattenResultData, QDateTime &startTime, QDateTime &endTime)
+void AMDSClientStartTimeToEndTimeDataRequest::setAttributesValues(const QString &bufferName, bool includeStatusData, bool flattenResultData, const QDateTime &startTime, const QDateTime &endTime)
 {
 	setBufferName(bufferName);
 	setIncludeStatusData(includeStatusData);

--- a/source/ClientRequest/AMDSClientStartTimeToEndTimeDataRequest.h
+++ b/source/ClientRequest/AMDSClientStartTimeToEndTimeDataRequest.h
@@ -29,7 +29,7 @@ public:
 	inline void setEndTime(const QDateTime &endTime) { endTime_ = endTime; }
 
 	/// Sets the values of all the data attributes of client request
-	void setAttributesValues(QString &bufferName, bool includeStatusData, bool flattenResultData, QDateTime &startTime, QDateTime &endTime);
+	void setAttributesValues(const QString &bufferName, bool includeStatusData, bool flattenResultData, const QDateTime &startTime, const QDateTime &endTime);
 
 	/// Writes this AMDSClientRelativeCountPlusCountDataRequest to an AMDSDataStream, returns 0 if no errors are encountered
 	virtual int writeToDataStream(AMDSDataStream *dataStream) const;

--- a/source/ClientRequest/AMDSClientStatisticsRequest.cpp
+++ b/source/ClientRequest/AMDSClientStatisticsRequest.cpp
@@ -76,7 +76,7 @@ int AMDSClientStatisticsRequest::readFromDataStream(AMDSDataStream *dataStream)
 	return AMDS_CLIENTREQUEST_SUCCESS;
 }
 
-QString AMDSClientStatisticsRequest::toString()
+QString AMDSClientStatisticsRequest::toString() const
 {
 	QString messageData = QString("Data of Statistics message (%1):").arg(socketKey());
 	for(int x = 0, size = packetStats().count(); x < size; x++) {

--- a/source/ClientRequest/AMDSClientStatisticsRequest.cpp
+++ b/source/ClientRequest/AMDSClientStatisticsRequest.cpp
@@ -1,7 +1,5 @@
 #include "source/ClientRequest/AMDSClientStatisticsRequest.h"
 
-#include <QDebug>
-
 #include "source/Connection/AMDSDataStream.h"
 
 AMDSClientStatisticsRequest::AMDSClientStatisticsRequest(QObject *parent) :
@@ -78,10 +76,12 @@ int AMDSClientStatisticsRequest::readFromDataStream(AMDSDataStream *dataStream)
 	return AMDS_CLIENTREQUEST_SUCCESS;
 }
 
-bool AMDSClientStatisticsRequest::validateResponse()
+QString AMDSClientStatisticsRequest::toString()
 {
-	for(int x = 0, size = packetStats().count(); x < size; x++)
-		qDebug() << "Packet Stats " << packetStats().at(x).name() << ": " << packetStats().at(x).allStats();
+	QString messageData = QString("Data of Statistics message (%1):").arg(socketKey());
+	for(int x = 0, size = packetStats().count(); x < size; x++) {
+		messageData = QString("%1\n\tPacket Stats %2").arg(messageData).arg(packetStats().at(x).toString());
+	}
 
-	return true;
+	return messageData;
 }

--- a/source/ClientRequest/AMDSClientStatisticsRequest.h
+++ b/source/ClientRequest/AMDSClientStatisticsRequest.h
@@ -29,8 +29,9 @@ public:
 	virtual int writeToDataStream(AMDSDataStream *dataStream) const;
 	/// Reads this AMDSClientStatisticsRequest from the AMDSDataStream, returns 0 if no errors are encountered
 	virtual int readFromDataStream(AMDSDataStream *dataStream);
-	/// validate the message response
-	virtual bool validateResponse();
+
+	/// implement the function to return a data string of the message
+	virtual QString toString();
 
 protected:
 	QList<AMDSPacketStats> packetStats_;

--- a/source/ClientRequest/AMDSClientStatisticsRequest.h
+++ b/source/ClientRequest/AMDSClientStatisticsRequest.h
@@ -31,7 +31,7 @@ public:
 	virtual int readFromDataStream(AMDSDataStream *dataStream);
 
 	/// implement the function to return a data string of the message
-	virtual QString toString();
+	virtual QString toString() const;
 
 protected:
 	QList<AMDSPacketStats> packetStats_;

--- a/source/Connection/AMDSClientTCPSocket.cpp
+++ b/source/Connection/AMDSClientTCPSocket.cpp
@@ -97,8 +97,10 @@ void AMDSClientTCPSocket::readClientRequestMessage()
 	case AMDSClientRequestDefinitions::StartTimeToEndTime:
 	case AMDSClientRequestDefinitions::MiddleTimePlusCountBeforeAndAfter:
 	case AMDSClientRequestDefinitions::Continuous:
-			if (clientRequest->validateResponse())
+			if (clientRequest->validateResponse()) {
 				socketKey_ = clientRequest->socketKey();
+				clientRequest->printData();
+			}
 			break;
 
 	default:

--- a/source/Connection/AMDSPacketStats.h
+++ b/source/Connection/AMDSPacketStats.h
@@ -24,7 +24,7 @@ public:
 	inline void setMaxOutboundBytes(quint64 maxOutboundBytes) { maxOutboundBytes_ = maxOutboundBytes; }
 	inline void setMaxTotalBytes(quint64 maxTotalBytes) { maxTotalBytes_ = maxTotalBytes; }
 
-	inline QString allStats() const { return QString("%1 %2 %3 %4 %5").arg(inboundBytes_).arg(outboundBytes_).arg(maxInboundBytes_).arg(maxOutboundBytes_).arg(maxTotalBytes_); }
+	inline QString toString() const { return QString("%1: %2 %3 %4 %5 %6").arg(name_).arg(inboundBytes_).arg(outboundBytes_).arg(maxInboundBytes_).arg(maxOutboundBytes_).arg(maxTotalBytes_); }
 
 protected:
 	QString name_;

--- a/source/Connection/AMDSServer.cpp
+++ b/source/Connection/AMDSServer.cpp
@@ -35,6 +35,7 @@ AMDSClientTCPSocket * AMDSServer::establishSocketConnection()
 	return clientTCPSocket;
 }
 
+
 void AMDSServer::onSocketDataReady(AMDSClientTCPSocket* clientTCPSocket, AMDSClientRequest *clientRequest)
 {
 	if (clientRequest->isContinuousMessage()) {
@@ -73,8 +74,8 @@ void AMDSServer::onSocketError(AMDSClientTCPSocket *clientTCPSocket, QAbstractSo
 		errorString = QString("The following error occurred: %1.").arg(clientTCPSocket->errorString());
 	}
 
-	emit serverError(this, socketErrorCode, clientTCPSocket->socketKey(), errorString);
 	removeTCPSocket(clientTCPSocket);
+	emit AMDSServerError(this, socketErrorCode, clientTCPSocket->socketKey(), errorString);
 }
 
 void AMDSServer::removeTCPSocket(AMDSClientTCPSocket *clientTCPSocket)

--- a/source/Connection/AMDSServer.h
+++ b/source/Connection/AMDSServer.h
@@ -36,7 +36,7 @@ public:
 
 signals:
 	/// signal to indicate that something wrong with the connection happened
-	void serverError(AMDSServer* server, int errorCode, QString socketKey, QString errorMessage);
+	void AMDSServerError(AMDSServer* server, int errorCode, QString socketKey, QString errorMessage);
 	/// signal to indicate that the data is sent from server for read
 	void requestDataReady(AMDSClientRequest*);
 

--- a/source/Connection/AMDSTCPDataServer.cpp
+++ b/source/Connection/AMDSTCPDataServer.cpp
@@ -159,8 +159,8 @@ void AMDSTCPDataServer::onClientRequestProcessed(AMDSClientRequest *processedReq
 	}
 
 	AMDSClientDataRequest *processedClientDataRequest = qobject_cast<AMDSClientDataRequest*>(processedRequest);
-	if(processedClientDataRequest) {
-		processedClientDataRequest->validateResponse();
+	if(processedClientDataRequest && processedClientDataRequest->validateResponse()) {
+		processedClientDataRequest->printData();
 	}
 
 	if (!processedClientDataRequest || !processedClientDataRequest->isContinuousMessage()) {

--- a/source/Connection/AMDSTCPDataServer.h
+++ b/source/Connection/AMDSTCPDataServer.h
@@ -7,7 +7,6 @@
 #include <QTcpSocket>
 #include <QHash>
 #include <QSignalMapper>
-#include <QDebug>
 #include <QStringList>
 #include <QNetworkConfigurationManager>
 #include <QSettings>

--- a/source/Connection/AMDSThreadedTCPDataServer.cpp
+++ b/source/Connection/AMDSThreadedTCPDataServer.cpp
@@ -23,7 +23,10 @@ AMDSThreadedTCPDataServer::~AMDSThreadedTCPDataServer()
 		thread_->quit();
 
 	server_->deleteLater();
+	server_ = 0;
+
 	thread_->deleteLater();
+	thread_ = 0;
 }
 
 AMDSTCPDataServer* AMDSThreadedTCPDataServer::server()

--- a/source/DataElement/AMDSAxisInfo.cpp
+++ b/source/DataElement/AMDSAxisInfo.cpp
@@ -16,3 +16,7 @@ AMDSAxisInfo::~AMDSAxisInfo()
 {
 }
 
+QString AMDSAxisInfo::toString()
+{
+	return QString("%1 %2 %3 %4 %5 %6 %7").arg(name()).arg(description()).arg(units()).arg(size()).arg(isUniform()).arg(start()).arg(increment());
+}

--- a/source/DataElement/AMDSAxisInfo.cpp
+++ b/source/DataElement/AMDSAxisInfo.cpp
@@ -16,7 +16,7 @@ AMDSAxisInfo::~AMDSAxisInfo()
 {
 }
 
-QString AMDSAxisInfo::toString()
+QString AMDSAxisInfo::toString() const
 {
 	return QString("%1 %2 %3 %4 %5 %6 %7").arg(name()).arg(description()).arg(units()).arg(size()).arg(isUniform()).arg(start()).arg(increment());
 }

--- a/source/DataElement/AMDSAxisInfo.cpp
+++ b/source/DataElement/AMDSAxisInfo.cpp
@@ -2,14 +2,24 @@
 
 AMDSAxisInfo::AMDSAxisInfo(const QString &name, quint32 size, const QString &description, const QString &units, bool isUniform)
 {
-	name_ = name;
-	size_ = size;
-	description_ = description;
-	units_ = units;
-	isUniform_ = isUniform;
+	setName(name);
+	setSize(size);
+	setDescription(description);
+	setUnits(units);
+	setIsUniform(isUniform);
+	setStart(0);
+	setIncrement(1);
+}
 
-	start_ = 0;
-	increment_ = 1;
+AMDSAxisInfo::AMDSAxisInfo(const AMDSAxisInfo &axisInfo )
+{
+	setName(axisInfo.name());
+	setSize(axisInfo.size());
+	setDescription(axisInfo.description());
+	setUnits(axisInfo.units());
+	setIsUniform(axisInfo.isUniform());
+	setStart(axisInfo.start());
+	setIncrement(axisInfo.increment());
 }
 
 AMDSAxisInfo::~AMDSAxisInfo()

--- a/source/DataElement/AMDSAxisInfo.h
+++ b/source/DataElement/AMDSAxisInfo.h
@@ -9,6 +9,7 @@ class AMDSAxisInfo
 public:
 	/// Constructor.
 	AMDSAxisInfo(const QString& name, quint32 size, const QString& description = QString(), const QString& units = QString(), bool isUniform = true );
+	AMDSAxisInfo(const AMDSAxisInfo &axisInfo );
 	/// Destructor.
 	virtual ~AMDSAxisInfo();
 

--- a/source/DataElement/AMDSAxisInfo.h
+++ b/source/DataElement/AMDSAxisInfo.h
@@ -24,15 +24,25 @@ public:
 	bool inline isUniform() const { return isUniform_; }
 	/// Relevent only when isUniform is true... these provide a fast way to compute the axis' independent values
 	qint16 inline start() const { return start_; }
+	/// Return the incrent information of the Axis
 	quint16 inline increment() const { return increment_; }
 
+	/// set the number of elements along the axis
 	void setSize(quint32 size) { size_ = size; }
+	/// set the naem of the axis
 	void setName(const QString &name) { name_ = name; }
+	/// set the description of the axis
 	void setDescription(const QString &description) { description_ = description; }
+	/// set the units of the axis
 	void setUnits(const QString &units) { units_ = units; }
+	/// set whether the values are uniformly spaces or not
 	void setIsUniform(bool isUniform) { isUniform_ = isUniform; }
 	void setStart(qint16 start) { start_ = start; }
+	/// set the increment information
 	void setIncrement(quint16 increment) { increment_ = increment; }
+
+	/// return the axis information as string
+	QString toString();
 
 protected:
 	/// Size: number of elements along the axis

--- a/source/DataElement/AMDSAxisInfo.h
+++ b/source/DataElement/AMDSAxisInfo.h
@@ -42,7 +42,7 @@ public:
 	void setIncrement(quint16 increment) { increment_ = increment; }
 
 	/// return the axis information as string
-	QString toString();
+	QString toString() const;
 
 protected:
 	/// Size: number of elements along the axis

--- a/source/DataElement/AMDSBuffer.h
+++ b/source/DataElement/AMDSBuffer.h
@@ -3,7 +3,6 @@
 
 #include <QVector>
 #include <QReadWriteLock>
-#include <QDebug>
 
 /**
   * Templated class which provides automatic AMDSBuffering of classes of type T. Allows for constant time additions to the

--- a/source/DataElement/AMDSBufferGroup.cpp
+++ b/source/DataElement/AMDSBufferGroup.cpp
@@ -68,37 +68,48 @@ void AMDSBufferGroup::processClientRequest(AMDSClientRequest *clientRequest){
 	emit clientRequestProcessed(clientRequest);
 }
 
-void AMDSBufferGroup::flattenData(QList<AMDSDataHolder *> *dataArray)
+bool AMDSBufferGroup::flattenData(QList<AMDSDataHolder *> *dataArray)
 {
-	if (!bufferGroupInfo_.flattenEnabled() || bufferGroupInfo_.flattenMethod() == AMDSBufferGroupInfo::NoFlatten) {
+	if (!bufferGroupInfo_.isFlattenEnabled() || bufferGroupInfo_.flattenMethod() == AMDSBufferGroupInfo::NoFlatten) {
 		AMDSErrorMon::alert(this, AMDS_SERVER_ALT_BUFFER_GROUP_DISABLE_FLATTEN, QString("The given buffergroup (%1) doesn't enable flatten feature or the flatten method is %2.").arg(bufferGroupInfo_.name()).arg(bufferGroupInfo_.flattenMethod()));
-		return;
+		return false;
 	}
 
 	// make the summarization operation
 	int totalDataSize = dataArray->size();
-	AMDSDataHolder *flattenDataHolder = dataArray->at(0);
-	for (int i = 1; i < totalDataSize; i++) {
-		AMDSDataHolder * dataHolder = dataArray->at(i);
-		if (flattenDataHolder && dataHolder) {
-			flattenDataHolder = (*flattenDataHolder) + (*dataHolder);
+	if (totalDataSize > 0) {
+		// make a copy of the first data holder
+		AMDSDataHolder *flattenDataHolder = AMDSDataHolderSupport::instantiateDataHolderFromInstance( dataArray->at(0) );
+		(*flattenDataHolder) = (*dataArray->at(0));
+		for (int i = 1; i < totalDataSize; i++) {
+			AMDSDataHolder * dataHolder = dataArray->at(i);
+			if (flattenDataHolder && dataHolder) {
+				AMDSDataHolder *tempDataHolder = flattenDataHolder;
+				flattenDataHolder = (*flattenDataHolder) + (*dataHolder);
+				tempDataHolder->deleteLater();
+			}
 		}
+
+		if (flattenDataHolder) {
+			switch (bufferGroupInfo_.flattenMethod()) {
+			case AMDSBufferGroupInfo::Summary:
+				break; // do nothing, since we already summrized the data
+			case AMDSBufferGroupInfo::Average: {
+				AMDSDataHolder *tempDataHolder = flattenDataHolder;
+				flattenDataHolder = (*flattenDataHolder) / totalDataSize;
+				tempDataHolder->deleteLater();
+				break;
+			}
+			default:
+				break;
+			}
+		}
+
+		dataArray->clear();
+		dataArray->append(flattenDataHolder);
 	}
 
-	if (flattenDataHolder) {
-		switch (bufferGroupInfo_.flattenMethod()) {
-		case AMDSBufferGroupInfo::Summary:
-			break; // do nothing, since we already summrized the data
-		case AMDSBufferGroupInfo::Average:
-			flattenDataHolder = (*flattenDataHolder) / totalDataSize;
-			break;
-		default:
-			break;
-		}
-	}
-
-	dataArray->clear();
-	dataArray->append(flattenDataHolder);
+	return true;
 }
 
 void AMDSBufferGroup::populateData(AMDSClientDataRequest* clientDataRequest, int startIndex, int endIndex)
@@ -119,12 +130,22 @@ void AMDSBufferGroup::populateData(AMDSClientDataRequest* clientDataRequest, int
 		targetDataArray.append(dataHolder);
 	}
 
+	// when doing flattening, the data holders in the targetDataArray are new instances, which need to be released after usage
+	// if not, the array hosts original data holder, which should NOT be released
+	bool releaseDataHolders = false;
 	if (clientDataRequest->flattenResultData()) {
-		flattenData(&targetDataArray);
+		releaseDataHolders = flattenData(&targetDataArray);
 	}
 
 	foreach (AMDSDataHolder * dataHolder, targetDataArray) {
-		clientDataRequest->appendData(dataHolder);
+		clientDataRequest->copyAndAppendData(dataHolder);
+	}
+
+	if (releaseDataHolders) {
+		foreach (AMDSDataHolder *dataHolder, targetDataArray) {
+			dataHolder->deleteLater();
+		}
+		targetDataArray.clear();
 	}
 }
 

--- a/source/DataElement/AMDSBufferGroup.h
+++ b/source/DataElement/AMDSBufferGroup.h
@@ -60,8 +60,8 @@ signals:
 protected:
 	/// Helper functions which populate request data based on the parameters passed:
 
-	/// Flatten the data based on the given flatten method
-	void flattenData(QList<AMDSDataHolder *> *dataArray);
+	/// Flatten the data based on the given flatten method, return True if no error happened
+	bool flattenData(QList<AMDSDataHolder *> *dataArray);
 	/// Fills the data to the clientRequest
 	void populateData(AMDSClientDataRequest* clientDataRequest, int startIndex, int endIndex);
 	/// Fills the request with count number of spectra after (and including) startTime

--- a/source/DataElement/AMDSBufferGroupInfo.cpp
+++ b/source/DataElement/AMDSBufferGroupInfo.cpp
@@ -26,7 +26,7 @@ AMDSBufferGroupInfo& AMDSBufferGroupInfo::operator=(const AMDSBufferGroupInfo& o
 	return *this;
 }
 
-QString AMDSBufferGroupInfo::toString()
+QString AMDSBufferGroupInfo::toString() const
 {
 	QString bufferGroupInfoDef = QString("%1 %2 %3 %4 %5 %6 %7").arg(name()).arg(description()).arg(units()).arg(rank()).arg(size().toString()).arg(flattenEnabled()?"true":"false").arg(flattenMethod());
 

--- a/source/DataElement/AMDSBufferGroupInfo.cpp
+++ b/source/DataElement/AMDSBufferGroupInfo.cpp
@@ -25,3 +25,16 @@ AMDSBufferGroupInfo& AMDSBufferGroupInfo::operator=(const AMDSBufferGroupInfo& o
 
 	return *this;
 }
+
+QString AMDSBufferGroupInfo::toString()
+{
+	QString bufferGroupInfoDef = QString("%1 %2 %3 %4 %5 %6 %7").arg(name()).arg(description()).arg(units()).arg(rank()).arg(size().toString()).arg(flattenEnabled()?"true":"false").arg(flattenMethod());
+
+	for(int x = 0, size = axes().count(); x < size; x++){
+		AMDSAxisInfo axisInfo = axes().at(x);
+		QString axisDef = QString("\tAxis (%1): %2").arg(x).arg(axisInfo.toString());
+		bufferGroupInfoDef = QString("%1\n%2").arg(bufferGroupInfoDef).arg(axisDef);
+	}
+
+	return bufferGroupInfoDef;
+}

--- a/source/DataElement/AMDSBufferGroupInfo.cpp
+++ b/source/DataElement/AMDSBufferGroupInfo.cpp
@@ -1,11 +1,10 @@
 #include "AMDSBufferGroupInfo.h"
 
-AMDSBufferGroupInfo::AMDSBufferGroupInfo(const QString &name, const QString &description, const QString &units, const bool flattenEnabled, const DataFlattenMethod flattenMethod, const QList<AMDSAxisInfo> &axes)
+AMDSBufferGroupInfo::AMDSBufferGroupInfo(const QString &name, const QString &description, const QString &units, const DataFlattenMethod flattenMethod, const QList<AMDSAxisInfo> &axes)
 {
 	setName(name);
 	setDescription(description);
 	setUnits(units);
-	setFlattenEnabled(flattenEnabled);
 	setFlattenMethod(flattenMethod);
 	setAxes(axes);
 }
@@ -19,7 +18,6 @@ AMDSBufferGroupInfo& AMDSBufferGroupInfo::operator=(const AMDSBufferGroupInfo& o
 	setName(other.name());
 	setDescription(other.description());
 	setUnits(other.units());
-	setFlattenEnabled(other.flattenEnabled());
 	setFlattenMethod(other.flattenMethod());
 	setAxes(other.axes());
 
@@ -28,7 +26,23 @@ AMDSBufferGroupInfo& AMDSBufferGroupInfo::operator=(const AMDSBufferGroupInfo& o
 
 QString AMDSBufferGroupInfo::toString()
 {
-	QString bufferGroupInfoDef = QString("%1 %2 %3 %4 %5 %6 %7").arg(name()).arg(description()).arg(units()).arg(rank()).arg(size().toString()).arg(flattenEnabled()?"true":"false").arg(flattenMethod());
+	QString flattenMethodStr;
+	switch(flattenMethod()) {
+	case Average:
+		flattenMethodStr = "Average";
+		break;
+	case Summary:
+		flattenMethodStr = "Summary";
+		break;
+	case NoFlatten:
+		flattenMethodStr = "NoFlatten";
+		break;
+	default:
+		flattenMethodStr = "Unknown";
+		break;
+	}
+
+	QString bufferGroupInfoDef = QString("%1 %2 %3 %4 %5 %6").arg(name()).arg(description()).arg(units()).arg(rank()).arg(size().toString()).arg(flattenMethodStr);
 
 	for(int x = 0, size = axes().count(); x < size; x++){
 		AMDSAxisInfo axisInfo = axes().at(x);

--- a/source/DataElement/AMDSBufferGroupInfo.h
+++ b/source/DataElement/AMDSBufferGroupInfo.h
@@ -16,7 +16,7 @@ public:
 		NoFlatten = 2
 	};
 
-	AMDSBufferGroupInfo(const QString& name = QString(), const QString& description = QString(), const QString& units = QString(), const bool flattenEnabled=false, const DataFlattenMethod flattenMethod=AMDSBufferGroupInfo::NoFlatten, const QList<AMDSAxisInfo>& axes = QList<AMDSAxisInfo>());
+	AMDSBufferGroupInfo(const QString& name = QString(), const QString& description = QString(), const QString& units = QString(), const DataFlattenMethod flattenMethod=AMDSBufferGroupInfo::NoFlatten, const QList<AMDSAxisInfo>& axes = QList<AMDSAxisInfo>());
 	/// Copy constructor
 	AMDSBufferGroupInfo(const AMDSBufferGroupInfo& other);
 	/// Assignment operator
@@ -29,7 +29,7 @@ public:
 	/// returns the units of the bufferGroupInfo
 	inline QString units() const { return units_; }
 	/// returns whether the bufferGroup is enabled flatten
-	inline bool flattenEnabled() const { return flattenEnabled_; }
+	inline bool isFlattenEnabled() const { return flattenMethod_ != NoFlatten; }
 	/// returns the flatten method of the bufferGroup
 	inline DataFlattenMethod flattenMethod()const { return flattenMethod_; }
 
@@ -56,8 +56,6 @@ public:
 	void setUnits(const QString &units) { units_ = units; }
 	/// Set the axes of the bufferGroupInfo
 	void setAxes(const QList<AMDSAxisInfo> &axes) { axes_ = axes; }
-	/// Set whether the bufferGroup can be flattened
-	void setFlattenEnabled(bool enabled) { flattenEnabled_ = enabled; }
 	/// Set how the bufferGroup should be flattened
 	void setFlattenMethod(DataFlattenMethod method) { flattenMethod_ = method; }
 
@@ -74,8 +72,6 @@ protected:
 	QString description_;
 	/// the unit of the bufferGroupInfo
 	QString units_;
-	/// the flag whether this buffer group allows to flatten data
-	bool flattenEnabled_;
 	/// the definition on how the data should be flattened
 	DataFlattenMethod flattenMethod_;
 

--- a/source/DataElement/AMDSBufferGroupInfo.h
+++ b/source/DataElement/AMDSBufferGroupInfo.h
@@ -64,6 +64,9 @@ public:
 	/// If the bufferGrou name is "Invalid", there should be no Data
 	bool includeData() const { return name_ != "Invalid"; }
 
+	/// convert the buffer group to a string
+	QString toString();
+
 protected:
 	/// the name of the bufferGroupInfo
 	QString name_;

--- a/source/DataElement/AMDSBufferGroupInfo.h
+++ b/source/DataElement/AMDSBufferGroupInfo.h
@@ -65,7 +65,7 @@ public:
 	bool includeData() const { return name_ != "Invalid"; }
 
 	/// convert the buffer group to a string
-	QString toString();
+	QString toString() const;
 
 protected:
 	/// the name of the bufferGroupInfo

--- a/source/DataElement/AMDSEventData.cpp
+++ b/source/DataElement/AMDSEventData.cpp
@@ -96,10 +96,10 @@ void AMDSFullEventData::cloneData(AMDSEventData *sourceEventData)
 		if (lightWeightEventData_)
 			lightWeightEventData_->deleteLater();
 
-		AMDSEventData *newEventData = AMDSEventDataSupport::instantiateEventDataFromInstance(sourceFullEventData->lightWeightEventData_);
+		AMDSEventData *newEventData = AMDSEventDataSupport::instantiateEventDataFromInstance(sourceFullEventData->lightWeightEventData());
 		lightWeightEventData_ = qobject_cast<AMDSLightWeightEventData *>(newEventData);
 		if (lightWeightEventData_)
-			(*lightWeightEventData_) = (*sourceFullEventData->lightWeightEventData_);
+			(*lightWeightEventData_) = (*sourceFullEventData->lightWeightEventData());
 
 		setEventType(sourceFullEventData->eventType());
 		setTimeScale(sourceFullEventData->timeScale());

--- a/source/DataElement/AMDSEventData.cpp
+++ b/source/DataElement/AMDSEventData.cpp
@@ -114,15 +114,6 @@ void AMDSFullEventData::cloneData(AMDSEventData *sourceEventData)
 	}
 }
 
-//AMDSFullEventData& AMDSFullEventData::operator =(AMDSFullEventData &sourceEventData)
-//{
-//	if (this != &sourceEventData) {
-//		cloneData(&sourceEventData);
-//	}
-
-//	return *this;
-//}
-
 bool AMDSFullEventData::writeToDataStream(AMDSDataStream *dataStream) const{
 	if(!lightWeightEventData_->writeToDataStream(dataStream))
 		return false;

--- a/source/DataElement/AMDSEventData.cpp
+++ b/source/DataElement/AMDSEventData.cpp
@@ -44,15 +44,6 @@ void AMDSLightWeightEventData::cloneData(AMDSEventData *sourceEventData)
 	setEventTime(sourceEventData->eventTime());
 }
 
-//AMDSLightWeightEventData& AMDSLightWeightEventData::operator =(AMDSLightWeightEventData &sourceEventData)
-//{
-//	if (this != &sourceEventData) {
-//		cloneData(&sourceEventData);
-//	}
-
-//	return *this;
-//}
-
 bool AMDSLightWeightEventData::writeToDataStream(AMDSDataStream *dataStream) const{
 	*dataStream << eventTime_;
 	if(dataStream->status() != QDataStream::Ok)

--- a/source/DataElement/AMDSEventData.cpp
+++ b/source/DataElement/AMDSEventData.cpp
@@ -83,8 +83,10 @@ AMDSFullEventData::AMDSFullEventData(AMDSFullEventData &eventData, QObject *pare
 
 AMDSFullEventData::~AMDSFullEventData()
 {
-	if (lightWeightEventData_)
+	if (lightWeightEventData_) {
 		lightWeightEventData_->deleteLater();
+		lightWeightEventData_ = 0;
+	}
 }
 
 void AMDSFullEventData::cloneData(AMDSEventData *sourceEventData)
@@ -123,9 +125,12 @@ bool AMDSFullEventData::writeToDataStream(AMDSDataStream *dataStream) const{
 }
 
 bool AMDSFullEventData::readFromDataStream(AMDSDataStream *dataStream){
-	if (lightWeightEventData_)
+	if (lightWeightEventData_) {
 		lightWeightEventData_->deleteLater();
+	}
 
+	AMDSEventData *newEventData = AMDSEventDataSupport::instantiateEventDataFromClassName(AMDSLightWeightEventData::staticMetaObject.className());
+	lightWeightEventData_ = qobject_cast<AMDSLightWeightEventData *>(newEventData);
 	if(!lightWeightEventData_->readFromDataStream(dataStream))
 		return false;
 

--- a/source/DataElement/AMDSEventData.h
+++ b/source/DataElement/AMDSEventData.h
@@ -72,8 +72,6 @@ public:
 
 	/// implement the function to copy the data of the source eventData to the current instance
 	virtual void cloneData(AMDSEventData *sourceEventData);
-//	/// implementationt the function to copy the data of the source eventData to the target instance
-//	virtual AMDSLightWeightEventData& operator =(AMDSLightWeightEventData &sourceEventData);
 
 	/// Writes this AMDSEventData to an AMDSDataStream, returns true if no errors are encountered
 	virtual bool writeToDataStream(AMDSDataStream *dataStream) const;
@@ -109,6 +107,11 @@ public:
 	virtual bool writeToDataStream(AMDSDataStream *dataStream) const;
 	/// Reads this AMDSEventData from the AMDSDataStream, returns true if no errors are encountered
 	virtual bool readFromDataStream(AMDSDataStream *dataStream);
+
+protected:
+	/// getter function to get the lightWeightEventData_ of AMDSFullEventData.
+	/// The reason to encapsulate this as protected is that the user of AMDSFullEventData should NOT be aware the existence of the instance of lightWeightEventData_
+	inline AMDSLightWeightEventData * lightWeightEventData() { return lightWeightEventData_; }
 
 protected:
 	AMDSLightWeightEventData *lightWeightEventData_;

--- a/source/DataElement/AMDSEventData.h
+++ b/source/DataElement/AMDSEventData.h
@@ -41,6 +41,11 @@ public:
 	virtual inline bool setTimeScale(AMDSEventData::TimeScale timeScale) = 0;
 	virtual inline bool setTimeUncertainty(quint16 timeUncertainty) = 0;
 
+	/// virtual function to copy the data of the source eventData to the current instance
+	virtual void cloneData(AMDSEventData *sourceEventData) = 0;
+	/// implementationt the function to copy the data of the source eventData to the target instance
+	virtual AMDSEventData& operator =(AMDSEventData &sourceEventData);
+
 	/// Writes this AMDSEventData to an AMDSDataStream, returns true if no errors are encountered
 	virtual bool writeToDataStream(AMDSDataStream *dataStream) const = 0;
 	/// Reads this AMDSEventData from the AMDSDataStream, returns true if no errors are encountered
@@ -52,6 +57,7 @@ class AMDSLightWeightEventData : public AMDSEventData
 Q_OBJECT
 public:
 	Q_INVOKABLE AMDSLightWeightEventData(QDateTime eventTime = QDateTime::currentDateTime(), QObject *parent = 0);
+	Q_INVOKABLE AMDSLightWeightEventData(AMDSLightWeightEventData &eventData, QObject *parent = 0);
 	virtual ~AMDSLightWeightEventData();
 
 	virtual QDateTime eventTime() const { return eventTime_; }
@@ -63,6 +69,11 @@ public:
 	virtual inline bool setEventType(AMDSEventData::EventType eventType);
 	virtual inline bool setTimeScale(AMDSEventData::TimeScale timeScale);
 	virtual inline bool setTimeUncertainty(quint16 timeUncertainty);
+
+	/// implement the function to copy the data of the source eventData to the current instance
+	virtual void cloneData(AMDSEventData *sourceEventData);
+//	/// implementationt the function to copy the data of the source eventData to the target instance
+//	virtual AMDSLightWeightEventData& operator =(AMDSLightWeightEventData &sourceEventData);
 
 	/// Writes this AMDSEventData to an AMDSDataStream, returns true if no errors are encountered
 	virtual bool writeToDataStream(AMDSDataStream *dataStream) const;
@@ -78,6 +89,7 @@ class AMDSFullEventData : public AMDSEventData
 Q_OBJECT
 public:
 	Q_INVOKABLE AMDSFullEventData(QDateTime eventTime = QDateTime::currentDateTime(), AMDSEventData::EventType eventType = AMDSEventData::SingleEvent, AMDSEventData::TimeScale timeScale = AMDSEventData::SecondsScale, quint16 timeUncertainty = 0, QObject *parent = 0);
+	Q_INVOKABLE AMDSFullEventData(AMDSFullEventData &eventData, QObject *parent = 0);
 	virtual ~AMDSFullEventData();
 
 	virtual QDateTime eventTime() const { return lightWeightEventData_->eventTime(); }
@@ -89,6 +101,11 @@ public:
 	virtual inline bool setEventType(AMDSEventData::EventType eventType);
 	virtual inline bool setTimeScale(AMDSEventData::TimeScale timeScale);
 	virtual inline bool setTimeUncertainty(quint16 timeUncertainty);
+
+	/// implement the function to copy the data of the source eventData to the current instance
+	virtual void cloneData(AMDSEventData *sourceEventData);
+//	/// implementationt the function to copy the data of the source eventData to the target instance
+//	virtual AMDSFullEventData& operator =(AMDSFullEventData &sourceEventData);
 
 	/// Writes this AMDSEventData to an AMDSDataStream, returns true if no errors are encountered
 	virtual bool writeToDataStream(AMDSDataStream *dataStream) const;

--- a/source/DataElement/AMDSEventData.h
+++ b/source/DataElement/AMDSEventData.h
@@ -104,8 +104,6 @@ public:
 
 	/// implement the function to copy the data of the source eventData to the current instance
 	virtual void cloneData(AMDSEventData *sourceEventData);
-//	/// implementationt the function to copy the data of the source eventData to the target instance
-//	virtual AMDSFullEventData& operator =(AMDSFullEventData &sourceEventData);
 
 	/// Writes this AMDSEventData to an AMDSDataStream, returns true if no errors are encountered
 	virtual bool writeToDataStream(AMDSDataStream *dataStream) const;

--- a/source/DataElement/AMDSEventDataSupport.cpp
+++ b/source/DataElement/AMDSEventDataSupport.cpp
@@ -41,6 +41,8 @@ namespace AMDSEventDataSupport{
 	{
 		if(!AMDSEventDataSupport::registeredClasses()->contains(AMDSLightWeightEventData::staticMetaObject.className()))
 			AMDSEventDataSupport::registerClass<AMDSLightWeightEventData>();
+		if(!AMDSEventDataSupport::registeredClasses()->contains(AMDSFullEventData::staticMetaObject.className()))
+			AMDSEventDataSupport::registerClass<AMDSFullEventData>();
 	}
 
 	const QHash<QString, AMDSEventDataObjectInfo>* registeredClasses() {
@@ -54,6 +56,13 @@ namespace AMDSEventDataSupport{
 				return eventData;
 		}
 		return 0;
+	}
+
+	AMDSEventData* instantiateEventDataFromInstance(const AMDSEventData *instance){
+		if (instance)
+			return instantiateEventDataFromClassName(instance->metaObject()->className());
+		else
+			return 0;
 	}
 
 	bool inheritsEventData(const QMetaObject *queryMetaObject){

--- a/source/DataElement/AMDSEventDataSupport.h
+++ b/source/DataElement/AMDSEventDataSupport.h
@@ -46,6 +46,7 @@ namespace AMDSEventDataSupport {
 	const QHash<QString, AMDSEventDataObjectInfo>* registeredClasses();
 
 	AMDSEventData* instantiateEventDataFromClassName(const QString &className);
+	AMDSEventData* instantiateEventDataFromInstance(const AMDSEventData *instance);
 
 	bool inheritsEventData(const QMetaObject *queryMetaObject);
 

--- a/source/DataElement/AMDSFlatArray.cpp
+++ b/source/DataElement/AMDSFlatArray.cpp
@@ -8,6 +8,7 @@ AMDSFlatArray::AMDSFlatArray(AMDSDataTypeDefinitions::DataType dataType, quint32
 
 AMDSFlatArray::~AMDSFlatArray()
 {
+	clear();
 }
 
 AMDSFlatArray AMDSFlatArray::operator +(AMDSFlatArray &dataFlatArray)

--- a/source/DataElement/AMDSFlatArray.h
+++ b/source/DataElement/AMDSFlatArray.h
@@ -3,8 +3,6 @@
 
 #include <QVector>
 
-#include <QDebug>
-
 #include "source/DataElement/AMDSDataTypeDefinitions.h"
 
 class AMDSFlatArray

--- a/source/DataElement/AMDSFlatArray.h
+++ b/source/DataElement/AMDSFlatArray.h
@@ -2,6 +2,7 @@
 #define AMDSFLATARRAY_H
 
 #include <QVector>
+#include <QString>
 
 #include "source/DataElement/AMDSDataTypeDefinitions.h"
 

--- a/source/DataHolder/AMDSDataHolder.cpp
+++ b/source/DataHolder/AMDSDataHolder.cpp
@@ -39,8 +39,10 @@ AMDSLightWeightDataHolder::AMDSLightWeightDataHolder(AMDSLightWeightDataHolder &
 
 AMDSLightWeightDataHolder::~AMDSLightWeightDataHolder()
 {
-	if (eventData_)
+	if (eventData_) {
 		eventData_->deleteLater();
+		eventData_ = 0;
+	}
 }
 
 AMDSDataTypeDefinitions::DataType AMDSLightWeightDataHolder::dataType() const{
@@ -102,8 +104,10 @@ AMDSFullDataHolder::AMDSFullDataHolder(AMDSFullDataHolder &sourceFullDataHolder,
 
 AMDSFullDataHolder::~AMDSFullDataHolder()
 {
-	if (lightWeightDataHolder_)
+	if (lightWeightDataHolder_) {
 		lightWeightDataHolder_->deleteLater();
+		lightWeightDataHolder_ = 0;
+	}
 
 	axes_.clear();
 }

--- a/source/DataHolder/AMDSDataHolder.cpp
+++ b/source/DataHolder/AMDSDataHolder.cpp
@@ -62,7 +62,7 @@ void AMDSLightWeightDataHolder::cloneData(AMDSDataHolder *sourceDataHolder)
 			eventData_->deleteLater();
 
 		eventData_ = AMDSEventDataSupport::instantiateEventDataFromInstance(sourceLightWeightDataHolder->eventData());
-		(*eventData_) = *(sourceLightWeightDataHolder->eventData_); // copy the values of the eventData over
+		(*eventData_) = *(sourceLightWeightDataHolder->eventData()); // copy the values of the eventData over
 	}
 }
 

--- a/source/DataHolder/AMDSDataHolder.cpp
+++ b/source/DataHolder/AMDSDataHolder.cpp
@@ -64,19 +64,6 @@ void AMDSLightWeightDataHolder::cloneData(AMDSDataHolder *sourceDataHolder)
 	}
 }
 
-//AMDSLightWeightDataHolder& AMDSLightWeightDataHolder::operator =(const AMDSLightWeightDataHolder &sourceDataHolder)
-//{
-//	if(this != &sourceDataHolder){
-//		if (eventData_)
-//			eventData_->deleteLater();
-
-//		eventData_ = AMDSEventDataSupport::instantiateEventDataFromInstance(sourceDataHolder.eventData());
-//		(*eventData_) = *(sourceDataHolder.eventData_); // copy the values of the eventData over
-//	}
-
-//	return (*this);
-//}
-
 bool AMDSLightWeightDataHolder::writeToDataStream(AMDSDataStream *dataStream, bool encodeDataType) const{
 	Q_UNUSED(encodeDataType)
 	dataStream->encodeEventDataType(*eventData_);
@@ -151,34 +138,6 @@ void AMDSFullDataHolder::cloneData(AMDSDataHolder *sourceDataHolder)
 		dataTypeStyle_ = sourceFullDataHolder->dataTypeStyle();
 	}
 }
-
-//AMDSFullDataHolder& AMDSFullDataHolder::operator =(const AMDSFullDataHolder &sourceDataHolder)
-//{
-//	if(this != &sourceDataHolder){
-//		if (lightWeightDataHolder_)
-//			lightWeightDataHolder_->deleteLater();
-
-////			foreach (AMDSAxisInfo axisInfo, axes_) {
-////				axes_.removeOne(axisInfo);
-////				delete &axisInfo;
-////			}
-//			axes_.clear();
-
-//		AMDSDataHolder *newDataHolder = AMDSDataHolderSupport::instantiateDataHolderFromInstance(sourceDataHolder.lightWeightDataHolder_);
-//		lightWeightDataHolder_ = qobject_cast<AMDSLightWeightDataHolder *>(newDataHolder);
-//		(*lightWeightDataHolder_) = (*sourceDataHolder.lightWeightDataHolder_);
-
-//		foreach (AMDSAxisInfo axisInfo, sourceDataHolder.axes()) {
-//			AMDSAxisInfo copyAxisInfo(axisInfo);
-//			axes_.append(copyAxisInfo);
-//		}
-
-//		axesStyle_ = sourceDataHolder.axesStyle();
-//		dataTypeStyle_ = sourceDataHolder.dataTypeStyle();
-//	}
-
-//	return (*this);
-//}
 
 bool AMDSFullDataHolder::writeToDataStream(AMDSDataStream *dataStream, bool encodeDataType) const{
 	dataStream->encodeDataHolderType(*lightWeightDataHolder_);

--- a/source/DataHolder/AMDSDataHolder.cpp
+++ b/source/DataHolder/AMDSDataHolder.cpp
@@ -129,9 +129,9 @@ void AMDSFullDataHolder::cloneData(AMDSDataHolder *sourceDataHolder)
 		if (lightWeightDataHolder_)
 			lightWeightDataHolder_->deleteLater();
 
-		AMDSDataHolder *newDataHolder = AMDSDataHolderSupport::instantiateDataHolderFromInstance(sourceFullDataHolder->lightWeightDataHolder_);
+		AMDSDataHolder *newDataHolder = AMDSDataHolderSupport::instantiateDataHolderFromInstance(sourceFullDataHolder->lightWeightDataHolder());
 		lightWeightDataHolder_ = qobject_cast<AMDSLightWeightDataHolder *>(newDataHolder);
-		(*lightWeightDataHolder_) = (*sourceFullDataHolder->lightWeightDataHolder_);
+		(*lightWeightDataHolder_) = (*sourceFullDataHolder->lightWeightDataHolder());
 
 		foreach (AMDSAxisInfo axisInfo, sourceFullDataHolder->axes()) {
 			AMDSAxisInfo copyAxisInfo(axisInfo);

--- a/source/DataHolder/AMDSDataHolder.h
+++ b/source/DataHolder/AMDSDataHolder.h
@@ -121,6 +121,10 @@ public:
 	/// implement the function to read this AMDSDataHolder from the AMDSDataStream, returns true if no errors are encountered
 	virtual bool readFromDataStream(AMDSDataStream *dataStream, AMDSDataTypeDefinitions::DataType decodeAsDataType);
 
+	/// getter function to get the eventData_ of AMDSEventData.
+	/// The reason to encapsulate this as protected is that the user of AMDSEventData should NOT be aware the existence of the instance of eventData_
+	inline AMDSEventData * eventData() { return eventData_; }
+
 protected:
 	/// the instance of event data, which provides the event information about the dataHolder
 	AMDSEventData *eventData_;
@@ -185,7 +189,7 @@ public:
 protected:
 	/// getter function to get the lightweightDataHolder of AMDSFullDataHolder.
 	/// The reason to encapsulate this as protected is that the user of AMDSFullDataHolder should NOT be aware the existence of the instance of lightweightDataHolder
-	inline AMDSLightWeightDataHolder * lightWeightDataHolder() { return AMDSLightWeightDataHolder; }
+	inline AMDSLightWeightDataHolder * lightWeightDataHolder() { return lightWeightDataHolder_; }
 
 protected:
 	/// instance of AMDSLightWightDataHolder as the real holder for data

--- a/source/DataHolder/AMDSDataHolder.h
+++ b/source/DataHolder/AMDSDataHolder.h
@@ -183,6 +183,11 @@ public:
 	virtual bool readFromDataStream(AMDSDataStream *dataStream, AMDSDataTypeDefinitions::DataType decodeAsDataType);
 
 protected:
+	/// getter function to get the lightweightDataHolder of AMDSFullDataHolder.
+	/// The reason to encapsulate this as protected is that the user of AMDSFullDataHolder should NOT be aware the existence of the instance of lightweightDataHolder
+	inline AMDSLightWeightDataHolder * lightWeightDataHolder() { return AMDSLightWeightDataHolder; }
+
+protected:
 	/// instance of AMDSLightWightDataHolder as the real holder for data
 	AMDSLightWeightDataHolder *lightWeightDataHolder_;
 

--- a/source/DataHolder/AMDSDataHolder.h
+++ b/source/DataHolder/AMDSDataHolder.h
@@ -115,8 +115,6 @@ public:
 
 	/// implement the function copy the value of source instance to the current instance
 	virtual void cloneData(AMDSDataHolder *dataHolder);
-//	/// implement the = operation of AMDSDataHolder, which will copy the value of source instance to the target one
-//	virtual AMDSLightWeightDataHolder& operator =(const AMDSLightWeightDataHolder &dataHolder);
 
 	/// implement the function to write this AMDSDataHolder to an AMDSDataStream, returns true if no errors are encountered
 	virtual bool writeToDataStream(AMDSDataStream *dataStream, bool encodeDataType) const;
@@ -173,8 +171,6 @@ public:
 
 	/// implement the function copy the value of source instance to the current instance
 	virtual void cloneData(AMDSDataHolder *dataHolder);
-//	/// implement the = operation of AMDSDataHolder, which will copy the value of source instance to the target one
-//	virtual AMDSFullDataHolder& operator =(const AMDSFullDataHolder &dataHolder);
 
 	/// implement the PLUS operation of AMDSDataHolder, which will plus the value of the two instances of AMDSDataHolder and return the new instance
 	virtual AMDSDataHolder* operator +(AMDSDataHolder &dataHolder) { return lightWeightDataHolder_->operator +(dataHolder); }

--- a/source/DataHolder/AMDSDataHolder.h
+++ b/source/DataHolder/AMDSDataHolder.h
@@ -77,6 +77,11 @@ public:
 	/// pure virtual function to define the Division operation of AMDSDataHolder: the value of the given handler will be divided by the given divisior
 	virtual AMDSDataHolder* operator /(quint32 divisor) = 0;
 
+	/// pure virtual function copy the value of source instance to the current instance
+	virtual void cloneData(AMDSDataHolder *dataHolder) = 0;
+	/// implement the = operation of AMDSDataHolder, which will copy the value of source instance to the target one
+	virtual AMDSDataHolder& operator =(AMDSDataHolder &dataHolder);
+
 	/// pure virtual function to write this AMDSDataHolder to an AMDSDataStream, returns true if no errors are encountered. By default the data type is encoded into the stream; however, this can be disabled and moved to a higher level if need be.
 	virtual bool writeToDataStream(AMDSDataStream *dataStream, bool encodeDataType = true) const = 0;
 	/// pure virtual function to read this AMDSDataHolder from the AMDSDataStream, returns true if no errors are encountered. By default the data type is decoded from the stream; however, passing a particular data type will assume that there is no data type encoded in the stream.
@@ -88,6 +93,7 @@ class AMDSLightWeightDataHolder : public AMDSDataHolder
 Q_OBJECT
 public:
 	AMDSLightWeightDataHolder(QObject *parent = 0);
+	AMDSLightWeightDataHolder(AMDSLightWeightDataHolder &sourceLightWeightDataHolder, QObject *parent = 0);
 	virtual ~AMDSLightWeightDataHolder();
 
 	/// implement the axesStyle function
@@ -107,6 +113,11 @@ public:
 	virtual bool operator >(const QDateTime &rhs) { return eventData()->eventTime() > rhs; }
 	virtual bool operator ==(const QDateTime &rhs) { return eventData()->eventTime() == rhs; }
 
+	/// implement the function copy the value of source instance to the current instance
+	virtual void cloneData(AMDSDataHolder *dataHolder);
+//	/// implement the = operation of AMDSDataHolder, which will copy the value of source instance to the target one
+//	virtual AMDSLightWeightDataHolder& operator =(const AMDSLightWeightDataHolder &dataHolder);
+
 	/// implement the function to write this AMDSDataHolder to an AMDSDataStream, returns true if no errors are encountered
 	virtual bool writeToDataStream(AMDSDataStream *dataStream, bool encodeDataType) const;
 	/// implement the function to read this AMDSDataHolder from the AMDSDataStream, returns true if no errors are encountered
@@ -122,6 +133,7 @@ class AMDSFullDataHolder : public AMDSDataHolder
 Q_OBJECT
 public:
 	AMDSFullDataHolder(AMDSDataHolder::AxesStyle axesStyle, AMDSDataHolder::DataTypeStyle dataTypeStyle, const QList<AMDSAxisInfo>& axes = QList<AMDSAxisInfo>(), QObject *parent = 0);
+	AMDSFullDataHolder(AMDSFullDataHolder &sourceFullDataHolder, QObject *parent = 0);
 	virtual ~AMDSFullDataHolder();
 
 	/// implement the axesStyle() function
@@ -158,6 +170,11 @@ public:
 	virtual bool operator <(const QDateTime &rhs) { return lightWeightDataHolder_->operator <(rhs); }
 	virtual bool operator >(const QDateTime &rhs) { return lightWeightDataHolder_->operator >(rhs); }
 	virtual bool operator ==(const QDateTime &rhs) { return lightWeightDataHolder_->operator ==(rhs); }
+
+	/// implement the function copy the value of source instance to the current instance
+	virtual void cloneData(AMDSDataHolder *dataHolder);
+//	/// implement the = operation of AMDSDataHolder, which will copy the value of source instance to the target one
+//	virtual AMDSFullDataHolder& operator =(const AMDSFullDataHolder &dataHolder);
 
 	/// implement the PLUS operation of AMDSDataHolder, which will plus the value of the two instances of AMDSDataHolder and return the new instance
 	virtual AMDSDataHolder* operator +(AMDSDataHolder &dataHolder) { return lightWeightDataHolder_->operator +(dataHolder); }

--- a/source/DataHolder/AMDSDataHolderSupport.cpp
+++ b/source/DataHolder/AMDSDataHolderSupport.cpp
@@ -61,6 +61,13 @@ namespace AMDSDataHolderSupport{
 		return 0;
 	}
 
+	AMDSDataHolder* instantiateDataHolderFromInstance(const AMDSDataHolder *dataHolder){
+		if (dataHolder)
+			return instantiateDataHolderFromClassName(dataHolder->metaObject()->className());
+		else
+			return 0;
+	}
+
 	bool inheritsDataHolder(const QMetaObject *queryMetaObject){
 		const QMetaObject *dataHolderMetaObject = &(AMDSDataHolder::staticMetaObject);
 		return AMDSMetaObjectSupport::inheritsClass(queryMetaObject, dataHolderMetaObject);

--- a/source/DataHolder/AMDSDataHolderSupport.h
+++ b/source/DataHolder/AMDSDataHolderSupport.h
@@ -47,6 +47,8 @@ namespace AMDSDataHolderSupport {
 
 	/// helper function to instantiate client request from the give type
 	AMDSDataHolder* instantiateDataHolderFromClassName(const QString &className);
+	/// helper function to instantiate client request from the give instance
+	AMDSDataHolder* instantiateDataHolderFromInstance(const AMDSDataHolder *dataHolder);
 
 	bool inheritsDataHolder(const QMetaObject *queryMetaObject);
 

--- a/source/DataHolder/AMDSGenericFlatArrayDataHolder.cpp
+++ b/source/DataHolder/AMDSGenericFlatArrayDataHolder.cpp
@@ -48,7 +48,7 @@ void AMDSLightWeightGenericFlatArrayDataHolder::cloneData(AMDSDataHolder *source
 	AMDSLightWeightDataHolder::cloneData(sourceDataHolder);
 
 	AMDSLightWeightGenericFlatArrayDataHolder *sourceLightWeightGenericFlatArrayDataHolder = qobject_cast<AMDSLightWeightGenericFlatArrayDataHolder *>(sourceDataHolder);
-	sourceLightWeightGenericFlatArrayDataHolder->valueFlatArray_.resetTargetArrayAndReplaceData(&valueFlatArray_);
+	sourceLightWeightGenericFlatArrayDataHolder->dataArray().resetTargetArrayAndReplaceData(&valueFlatArray_);
 }
 
 bool AMDSLightWeightGenericFlatArrayDataHolder::writeToDataStream(AMDSDataStream *dataStream, bool encodeDataType) const{

--- a/source/DataHolder/AMDSGenericFlatArrayDataHolder.cpp
+++ b/source/DataHolder/AMDSGenericFlatArrayDataHolder.cpp
@@ -4,9 +4,15 @@
 #include "source/DataHolder/AMDSDataHolderSupport.h"
 #include "source/util/AMDSErrorMonitor.h"
 
-AMDSLightWeightGenericFlatArrayDataHolder::AMDSLightWeightGenericFlatArrayDataHolder(AMDSDataTypeDefinitions::DataType dataType, quint32 size, QObject *parent) :
-	AMDSLightWeightDataHolder(parent), valueFlatArray_(dataType, size)
+AMDSLightWeightGenericFlatArrayDataHolder::AMDSLightWeightGenericFlatArrayDataHolder(AMDSDataTypeDefinitions::DataType dataType, quint32 size, QObject *parent)
+	:AMDSLightWeightDataHolder(parent), valueFlatArray_(dataType, size)
 {
+}
+
+AMDSLightWeightGenericFlatArrayDataHolder::AMDSLightWeightGenericFlatArrayDataHolder(AMDSLightWeightGenericFlatArrayDataHolder* sourceDataHolder, QObject *parent)
+	:AMDSLightWeightDataHolder(parent), valueFlatArray_(sourceDataHolder->valueFlatArray_.dataType(), sourceDataHolder->valueFlatArray_.size())
+{
+	cloneData(sourceDataHolder);
 }
 
 AMDSLightWeightGenericFlatArrayDataHolder::~AMDSLightWeightGenericFlatArrayDataHolder()
@@ -35,6 +41,14 @@ AMDSDataHolder* AMDSLightWeightGenericFlatArrayDataHolder::operator /(const quin
 	AMDSDataHolder* targetDataHolder = AMDSDataHolderSupport::instantiateDataHolderFromClassName(metaObject()->className());
 	targetDataHolder->setData(&data);
 	return targetDataHolder;
+}
+
+void AMDSLightWeightGenericFlatArrayDataHolder::cloneData(AMDSDataHolder *sourceDataHolder)
+{
+	AMDSLightWeightDataHolder::cloneData(sourceDataHolder);
+
+	AMDSLightWeightGenericFlatArrayDataHolder *sourceLightWeightGenericFlatArrayDataHolder = qobject_cast<AMDSLightWeightGenericFlatArrayDataHolder *>(sourceDataHolder);
+	sourceLightWeightGenericFlatArrayDataHolder->valueFlatArray_.resetTargetArrayAndReplaceData(&valueFlatArray_);
 }
 
 bool AMDSLightWeightGenericFlatArrayDataHolder::writeToDataStream(AMDSDataStream *dataStream, bool encodeDataType) const{

--- a/source/DataHolder/AMDSGenericFlatArrayDataHolder.h
+++ b/source/DataHolder/AMDSGenericFlatArrayDataHolder.h
@@ -8,6 +8,7 @@ class AMDSLightWeightGenericFlatArrayDataHolder : public AMDSLightWeightDataHold
 Q_OBJECT
 public:
 	AMDSLightWeightGenericFlatArrayDataHolder(AMDSDataTypeDefinitions::DataType dataType = AMDSDataTypeDefinitions::Double, quint32 size = 2, QObject *parent = 0);
+	AMDSLightWeightGenericFlatArrayDataHolder(AMDSLightWeightGenericFlatArrayDataHolder* sourceDataHolder, QObject *parent = 0);
 	virtual ~AMDSLightWeightGenericFlatArrayDataHolder();
 
 	/// Implement the function to return the number of points this measurement spans (A scalar value is "1" point, a 1D Detector is the same as its dimension, higher-D detectors are the products of their dimensions)
@@ -25,6 +26,8 @@ public:
 	/// implement the function to return the data string
 	virtual QString printData() { return valueFlatArray_.printData(); }
 
+	/// reimplement the function copy the value of source instance to the current instance
+	virtual void cloneData(AMDSDataHolder *dataHolder);
 	/// reimplement the function to write this AMDSDataHolder to an AMDSDataStream, returns true if no errors are encountered
 	virtual bool writeToDataStream(AMDSDataStream *dataStream, bool encodeDataType) const;
 	/// reimplement the function to read this AMDSDataHolder from the AMDSDataStream, returns true if no errors are encountered

--- a/source/DataHolder/AMDSGenericFlatArrayDataHolder.h
+++ b/source/DataHolder/AMDSGenericFlatArrayDataHolder.h
@@ -22,7 +22,7 @@ public:
 	/// implement the data function to read data from valueFlatArray_ and write data to the given outputArray
 	virtual bool data(AMDSFlatArray *outputArray) const { return valueFlatArray_.resetTargetArrayAndReplaceData(outputArray); }
 	/// implement the setData function to update valueFlatArray_ with given inputArray
-	virtual void setData(AMDSFlatArray *inputArray) { inputArray->copyDataToTargetArray(&valueFlatArray_); }
+	virtual void setData(AMDSFlatArray *inputArray) { inputArray->resetTargetArrayAndReplaceData(&valueFlatArray_); }
 	/// implement the function to return the data string
 	virtual QString printData() { return valueFlatArray_.printData(); }
 

--- a/source/DataHolder/AMDSScalarDataHolder.cpp
+++ b/source/DataHolder/AMDSScalarDataHolder.cpp
@@ -8,6 +8,11 @@ AMDSLightWeightScalarDataHolder::AMDSLightWeightScalarDataHolder(AMDSDataTypeDef
 	eventData_ = new AMDSLightWeightEventData();
 }
 
+AMDSLightWeightScalarDataHolder::AMDSLightWeightScalarDataHolder(AMDSLightWeightScalarDataHolder *sourceDataHolder, QObject *parent )
+	:AMDSLightWeightGenericFlatArrayDataHolder(sourceDataHolder, parent)
+{
+}
+
 AMDSLightWeightScalarDataHolder::~AMDSLightWeightScalarDataHolder()
 {
 }

--- a/source/DataHolder/AMDSScalarDataHolder.h
+++ b/source/DataHolder/AMDSScalarDataHolder.h
@@ -8,6 +8,7 @@ class AMDSLightWeightScalarDataHolder : public AMDSLightWeightGenericFlatArrayDa
 Q_OBJECT
 public:
 	Q_INVOKABLE AMDSLightWeightScalarDataHolder(AMDSDataTypeDefinitions::DataType dataType = AMDSDataTypeDefinitions::Double, QObject *parent = 0);
+	Q_INVOKABLE AMDSLightWeightScalarDataHolder(AMDSLightWeightScalarDataHolder *sourceDataHolder, QObject *parent = 0);
 	virtual ~AMDSLightWeightScalarDataHolder();
 
 	/// implement the function to return axes information

--- a/source/DataHolder/AMDSSpectralDataHolder.cpp
+++ b/source/DataHolder/AMDSSpectralDataHolder.cpp
@@ -8,6 +8,12 @@ AMDSLightWeightSpectralDataHolder::AMDSLightWeightSpectralDataHolder(AMDSDataTyp
 	eventData_ = new AMDSLightWeightEventData();
 }
 
+AMDSLightWeightSpectralDataHolder::AMDSLightWeightSpectralDataHolder(AMDSLightWeightSpectralDataHolder *sourceDataHolder, QObject *parent)
+	:AMDSLightWeightGenericFlatArrayDataHolder(sourceDataHolder, parent)
+{
+
+}
+
 AMDSLightWeightSpectralDataHolder::~AMDSLightWeightSpectralDataHolder()
 {
 }

--- a/source/DataHolder/AMDSSpectralDataHolder.h
+++ b/source/DataHolder/AMDSSpectralDataHolder.h
@@ -8,6 +8,7 @@ class AMDSLightWeightSpectralDataHolder : public AMDSLightWeightGenericFlatArray
 Q_OBJECT
 public:
 	Q_INVOKABLE AMDSLightWeightSpectralDataHolder(AMDSDataTypeDefinitions::DataType dataType = AMDSDataTypeDefinitions::Double, quint32 size = 2, QObject *parent = 0);
+	Q_INVOKABLE AMDSLightWeightSpectralDataHolder(AMDSLightWeightSpectralDataHolder *sourceDataHolder, QObject *parent = 0);
 	virtual ~AMDSLightWeightSpectralDataHolder();
 
 	/// implement the function to return axes information

--- a/source/appController/AMDSClientAppController.cpp
+++ b/source/appController/AMDSClientAppController.cpp
@@ -45,7 +45,7 @@ bool AMDSClientAppController::isSessionOpen()
 	return (!networkSession_ || networkSession_->isOpen());
 }
 
-QStringList AMDSClientAppController::getBufferNamesByServer(QString serverIdentifier)
+QStringList AMDSClientAppController::getBufferNamesByServer(const QString &serverIdentifier)
 {
 	QStringList bufferNames;
 
@@ -59,7 +59,7 @@ QStringList AMDSClientAppController::getBufferNamesByServer(QString serverIdenti
 	return bufferNames;
 }
 
-QStringList AMDSClientAppController::getActiveSocketKeysByServer(QString &serverIdentifier)
+QStringList AMDSClientAppController::getActiveSocketKeysByServer(const QString &serverIdentifier)
 {
 	QStringList activeSocketKeys;
 
@@ -99,7 +99,7 @@ void AMDSClientAppController::openNetworkSession()
 	}
 }
 
-void AMDSClientAppController::connectToServer(QString &hostName, quint16 portNumber)
+void AMDSClientAppController::connectToServer(const QString &hostName, quint16 portNumber)
 {
 	QString serverIdentifier = AMDSServer::generateServerIdentifier(hostName, portNumber);
 	AMDSServer * server = getServerByServerIdentifier(serverIdentifier);
@@ -117,7 +117,7 @@ void AMDSClientAppController::connectToServer(QString &hostName, quint16 portNum
 	}
 }
 
-void AMDSClientAppController::disconnectWithServer(QString serverIdentifier)
+void AMDSClientAppController::disconnectWithServer(const QString &serverIdentifier)
 {
 	AMDSServer * server = getServerByServerIdentifier(serverIdentifier);
 	if (server) {
@@ -130,7 +130,7 @@ void AMDSClientAppController::disconnectWithServer(QString serverIdentifier)
 	}
 }
 
-void AMDSClientAppController::requestClientData(QString &hostName, quint16 portNumber)
+void AMDSClientAppController::requestClientData(const QString &hostName, quint16 portNumber)
 {
 	AMDSClientTCPSocket * clientTCPSocket = establishSocketConnection(hostName, portNumber);
 	if (clientTCPSocket) {
@@ -141,7 +141,7 @@ void AMDSClientAppController::requestClientData(QString &hostName, quint16 portN
 	}
 }
 
-void AMDSClientAppController::requestClientData(QString &hostName, quint16 portNumber, QString &bufferName)
+void AMDSClientAppController::requestClientData(const QString &hostName, quint16 portNumber, const QString &bufferName)
 {
 	AMDSClientTCPSocket * clientTCPSocket = establishSocketConnection(hostName, portNumber);
 	if (clientTCPSocket) {
@@ -157,7 +157,7 @@ void AMDSClientAppController::requestClientData(QString &hostName, quint16 portN
 	}
 }
 
-void AMDSClientAppController::requestClientData(QString &hostName, quint16 portNumber, QString &bufferName, QDateTime &startTime, quint64 count, bool includeStatus, bool enableFlattening)
+void AMDSClientAppController::requestClientData(const QString &hostName, quint16 portNumber, const QString &bufferName, const QDateTime &startTime, quint64 count, bool includeStatus, bool enableFlattening)
 {
 	AMDSClientTCPSocket * clientTCPSocket = establishSocketConnection(hostName, portNumber);
 	if (clientTCPSocket) {
@@ -173,7 +173,7 @@ void AMDSClientAppController::requestClientData(QString &hostName, quint16 portN
 	}
 }
 
-void AMDSClientAppController::requestClientData(QString &hostName, quint16 portNumber, QString &bufferName, quint64 relativeCount, quint64 count, bool includeStatus, bool enableFlattening)
+void AMDSClientAppController::requestClientData(const QString &hostName, quint16 portNumber, const QString &bufferName, quint64 relativeCount, quint64 count, bool includeStatus, bool enableFlattening)
 {
 	AMDSClientTCPSocket * clientTCPSocket = establishSocketConnection(hostName, portNumber);
 	if (clientTCPSocket) {
@@ -189,7 +189,7 @@ void AMDSClientAppController::requestClientData(QString &hostName, quint16 portN
 	}
 }
 
-void AMDSClientAppController::requestClientData(QString &hostName, quint16 portNumber, QString &bufferName, QDateTime &startTime, QDateTime &endTime, bool includeStatus, bool enableFlattening)
+void AMDSClientAppController::requestClientData(const QString &hostName, quint16 portNumber, const QString &bufferName, const QDateTime &startTime, const QDateTime &endTime, bool includeStatus, bool enableFlattening)
 {
 	AMDSClientTCPSocket * clientTCPSocket = establishSocketConnection(hostName, portNumber);
 	if (clientTCPSocket) {
@@ -205,7 +205,7 @@ void AMDSClientAppController::requestClientData(QString &hostName, quint16 portN
 	}
 }
 
-void AMDSClientAppController::requestClientData(QString &hostName, quint16 portNumber, QString &bufferName, QDateTime &middleTime, quint64 countBefore, quint64 countAfter, bool includeStatus, bool enableFlattening)
+void AMDSClientAppController::requestClientData(const QString &hostName, quint16 portNumber, const QString &bufferName, const QDateTime &middleTime, quint64 countBefore, quint64 countAfter, bool includeStatus, bool enableFlattening)
 {
 	AMDSClientTCPSocket * clientTCPSocket = establishSocketConnection(hostName, portNumber);
 	if (clientTCPSocket) {
@@ -222,7 +222,7 @@ void AMDSClientAppController::requestClientData(QString &hostName, quint16 portN
 	}
 }
 
-void AMDSClientAppController::requestClientData(QString &hostName, quint16 portNumber, QStringList &bufferNames, quint64 updateInterval, bool includeStatus, bool enableFlattening, QString handShakeSocketKey)
+void AMDSClientAppController::requestClientData(const QString &hostName, quint16 portNumber, const QStringList &bufferNames, quint64 updateInterval, bool includeStatus, bool enableFlattening, QString handShakeSocketKey)
 {
 	AMDSClientTCPSocket * clientTCPSocket = establishSocketConnection(hostName, portNumber);
 	if (clientTCPSocket) {
@@ -243,7 +243,7 @@ void AMDSClientAppController::requestClientData(QString &hostName, quint16 portN
 	}
 }
 
-void AMDSClientAppController::onAMDSServerError(AMDSServer* server, int errorCode, QString socketKey, QString errorMessage)
+void AMDSClientAppController::onAMDSServerError(AMDSServer* server, int errorCode, const QString &socketKey, const QString &errorMessage)
 {
 	Q_UNUSED(socketKey)
 
@@ -275,7 +275,7 @@ void AMDSClientAppController::onNetworkSessionOpened()
 	emit networkSessionOpened();
 }
 
-AMDSClientTCPSocket * AMDSClientAppController::establishSocketConnection(QString &hostName, quint16 portNumber)
+AMDSClientTCPSocket * AMDSClientAppController::establishSocketConnection(const QString &hostName, quint16 portNumber)
 {
 	AMDSClientTCPSocket * clientTCPSocket = 0;
 

--- a/source/appController/AMDSClientAppController.cpp
+++ b/source/appController/AMDSClientAppController.cpp
@@ -36,6 +36,7 @@ AMDSClientAppController::~AMDSClientAppController()
 	if (networkSession_) {
 		disconnect(networkSession_, SIGNAL(opened()), this, SLOT(onNetworkSessionOpened()));
 		networkSession_->deleteLater();
+		networkSession_ = 0;
 	}
 }
 

--- a/source/appController/AMDSClientAppController.h
+++ b/source/appController/AMDSClientAppController.h
@@ -36,34 +36,34 @@ public:
 	bool isSessionOpen();
 
 	/// helper function to return the server by given identifier
-	inline AMDSServer *getServerByServerIdentifier(QString serverIdentifier) { return activeServers_.value(serverIdentifier, 0);}
+	inline AMDSServer *getServerByServerIdentifier(const QString &serverIdentifier) { return activeServers_.value(serverIdentifier, 0);}
 	/// helper function to return the list of buffers defined by a give host server
-	QStringList getBufferNamesByServer(QString serverIdentifier);
+	QStringList getBufferNamesByServer(const QString &serverIdentifier);
 	/// helper function to return the list of socketKeys of active connection by a give host server
-	QStringList getActiveSocketKeysByServer(QString &serverIdentifier);
+	QStringList getActiveSocketKeysByServer(const QString &serverIdentifier);
 
 	/// open a new network session
 	void openNetworkSession();
 
 	/// request to establish a connection to a specific hostName and the portNumber
-	void connectToServer(QString &hostName, quint16 portNumber);
+	void connectToServer(const QString &hostName, quint16 portNumber);
 	/// request disconnection with a given server identifier
-	void disconnectWithServer(QString serverIdentifier);
+	void disconnectWithServer(const QString &serverIdentifier);
 
 	/// request data from server for Statistics
-	void requestClientData(QString &hostName, quint16 portNumber);
+	void requestClientData(const QString &hostName, quint16 portNumber);
 	/// request data from server for Instrospection
-	void requestClientData(QString &hostName, quint16 portNumber, QString &bufferName);
+	void requestClientData(const QString &hostName, quint16 portNumber, const QString &bufferName);
 	/// request data from server for StartTimePlusCount
-	void requestClientData(QString &hostName, quint16 portNumber, QString &bufferName, QDateTime &startTime, quint64 count, bool includeStatus=false, bool enableFlattening=false);
+	void requestClientData(const QString &hostName, quint16 portNumber, const QString &bufferName, const QDateTime &startTime, quint64 count, bool includeStatus=false, bool enableFlattening=false);
 	/// request data from server for RelativeCountPlusCount
-	void requestClientData(QString &hostName, quint16 portNumber, QString &bufferName, quint64 relativeCount, quint64 count, bool includeStatus=false, bool enableFlattening=false);
+	void requestClientData(const QString &hostName, quint16 portNumber, const QString &bufferName, quint64 relativeCount, quint64 count, bool includeStatus=false, bool enableFlattening=false);
 	/// request data from server for StartTimeToEndTime
-	void requestClientData(QString &hostName, quint16 portNumber, QString &bufferName, QDateTime &startTime, QDateTime &endTime, bool includeStatus=false, bool enableFlattening=false);
+	void requestClientData(const QString &hostName, quint16 portNumber, const QString &bufferName, const QDateTime &startTime, const QDateTime &endTime, bool includeStatus=false, bool enableFlattening=false);
 	/// request data from server for MiddleTimePlusCountBeforeAndAfter
-	void requestClientData(QString &hostName, quint16 portNumber, QString &bufferName, QDateTime &middleTime, quint64 countBefore, quint64 countAfter, bool includeStatus=false, bool enableFlattening=false);
+	void requestClientData(const QString &hostName, quint16 portNumber, const QString &bufferName, const QDateTime &middleTime, quint64 countBefore, quint64 countAfter, bool includeStatus=false, bool enableFlattening=false);
 	/// request data from server for Continuous
-	void requestClientData(QString &hostName, quint16 portNumber, QStringList &bufferNames, quint64 updateInterval, bool includeStatus=false, bool enableFlattening=false, QString handShakeSocketKey="");
+	void requestClientData(const QString &hostName, quint16 portNumber, const QStringList &bufferNames, quint64 updateInterval, bool includeStatus=false, bool enableFlattening=false, QString handShakeSocketKey="");
 
 signals:
 	/// signal to indicate that the manager object is opening a network session
@@ -72,15 +72,15 @@ signals:
 	void networkSessionOpened();
 
 	/// signal to indicate that a new server is connected
-	void newServerConnected(QString hostIdentifier);
+	void newServerConnected(const QString &hostIdentifier);
 	/// signal to indicate that there are server errors
-	void serverError(int errorCode, bool disconnectServer, QString hostIdentifier, QString errorMessage);
+	void serverError(int errorCode, bool disconnectServer, const QString &hostIdentifier, const QString &errorMessage);
 	/// signal to indicate that the data is sent from server for read
 	void requestDataReady(AMDSClientRequest*);
 
 public slots:
 	/// slot to handle socket error signal from the server
-	void onAMDSServerError(AMDSServer* server, int errorCode, QString socketKey, QString errorMessage);
+	void onAMDSServerError(AMDSServer* server, int errorCode, const QString &socketKey, const QString &errorMessage);
 
 private slots:
 	/// slot to handle the signal of network session opened
@@ -88,7 +88,7 @@ private slots:
 
 private:
 	/// establish TCP socket connection to a specific hostName and the portNumber
-	AMDSClientTCPSocket * establishSocketConnection(QString &hostName, quint16 portNumber);
+	AMDSClientTCPSocket * establishSocketConnection(const QString &hostName, quint16 portNumber);
 	/// helper function to instantiate client request based on the request type
 	AMDSClientRequest *instantiateClientRequest(AMDSClientRequestDefinitions::RequestType clientRequestType);
 

--- a/source/appController/AMDSClientAppController.h
+++ b/source/appController/AMDSClientAppController.h
@@ -40,31 +40,29 @@ public:
 	/// helper function to return the list of buffers defined by a give host server
 	QStringList getBufferNamesByServer(QString serverIdentifier);
 	/// helper function to return the list of socketKeys of active connection by a give host server
-	QStringList getActiveSocketKeysByServer(QString serverIdentifier);
+	QStringList getActiveSocketKeysByServer(QString &serverIdentifier);
 
-	/// slot to open a network session
+	/// open a new network session
 	void openNetworkSession();
 
-	/// slot to request a connection to a specific hostName and the portNumber
+	/// request to establish a connection to a specific hostName and the portNumber
 	void connectToServer(QString &hostName, quint16 portNumber);
-	/// slot to request disconnection with a given server identifier
-	void disconnectWithServer(QString &serverIdentifier);
-	/// slot to establish TCP socket connection to a specific hostName and the portNumber
-	AMDSClientTCPSocket * establishSocketConnection(QString &hostName, quint16 portNumber);
+	/// request disconnection with a given server identifier
+	void disconnectWithServer(QString serverIdentifier);
 
-	/// slot to request data from server for Statistics
+	/// request data from server for Statistics
 	void requestClientData(QString &hostName, quint16 portNumber);
-	/// slot to request data from server for Instrospection
+	/// request data from server for Instrospection
 	void requestClientData(QString &hostName, quint16 portNumber, QString &bufferName);
-	/// slot to request data from server for StartTimePlusCount
+	/// request data from server for StartTimePlusCount
 	void requestClientData(QString &hostName, quint16 portNumber, QString &bufferName, QDateTime &startTime, quint64 count, bool includeStatus=false, bool enableFlattening=false);
-	/// slot to request data from server for RelativeCountPlusCount
+	/// request data from server for RelativeCountPlusCount
 	void requestClientData(QString &hostName, quint16 portNumber, QString &bufferName, quint64 relativeCount, quint64 count, bool includeStatus=false, bool enableFlattening=false);
-	/// slot to request data from server for StartTimeToEndTime
+	/// request data from server for StartTimeToEndTime
 	void requestClientData(QString &hostName, quint16 portNumber, QString &bufferName, QDateTime &startTime, QDateTime &endTime, bool includeStatus=false, bool enableFlattening=false);
-	/// slot to request data from server for MiddleTimePlusCountBeforeAndAfter
+	/// request data from server for MiddleTimePlusCountBeforeAndAfter
 	void requestClientData(QString &hostName, quint16 portNumber, QString &bufferName, QDateTime &middleTime, quint64 countBefore, quint64 countAfter, bool includeStatus=false, bool enableFlattening=false);
-	/// slot to request data from server for Continuous
+	/// request data from server for Continuous
 	void requestClientData(QString &hostName, quint16 portNumber, QStringList &bufferNames, quint64 updateInterval, bool includeStatus=false, bool enableFlattening=false, QString handShakeSocketKey="");
 
 signals:
@@ -76,19 +74,21 @@ signals:
 	/// signal to indicate that a new server is connected
 	void newServerConnected(QString hostIdentifier);
 	/// signal to indicate that there are server errors
-	void serverError(int errorCode, QString hostIdentifier, QString errorMessage);
+	void serverError(int errorCode, bool disconnectServer, QString hostIdentifier, QString errorMessage);
 	/// signal to indicate that the data is sent from server for read
 	void requestDataReady(AMDSClientRequest*);
 
 public slots:
 	/// slot to handle socket error signal from the server
-	void onServerError(AMDSServer* server, int errorCode, QString socketKey, QString errorMessage);
+	void onAMDSServerError(AMDSServer* server, int errorCode, QString socketKey, QString errorMessage);
 
 private slots:
 	/// slot to handle the signal of network session opened
 	void onNetworkSessionOpened();
 
 private:
+	/// establish TCP socket connection to a specific hostName and the portNumber
+	AMDSClientTCPSocket * establishSocketConnection(QString &hostName, quint16 portNumber);
 	/// helper function to instantiate client request based on the request type
 	AMDSClientRequest *instantiateClientRequest(AMDSClientRequestDefinitions::RequestType clientRequestType);
 


### PR DESCRIPTION
- refine the client logic of send data request to server
- fix a bug for AMDSClientUi, we should only update activeContinuousMessageCombox when the active connections are changed. Otherwise, the combox will keep updating and we can't choose and send handshake message
- fix a bug for server error: when a socket connection is disconnected,
  the client will remove the active servers. It is incorrect. We should
  only remove the activeServer from clientAppController when severe error
  happened or requested to disconnect.
