### PR TITLE
PullRequest for Issue67: there are memory leak when doing data flattening

### DIFF
--- a/source/AMDSCentralServer.cpp
+++ b/source/AMDSCentralServer.cpp
@@ -55,7 +55,7 @@ void AMDSCentralServer::onDataServerClientRequestReady(AMDSClientRequest *client
 				QMap<QString, AMDSThreadedBufferGroup*>::const_iterator i = bufferGroups_.constBegin();
 				while (i != bufferGroups_.constEnd()) {
 					AMDSBufferGroupInfo oneInfo = i.value()->bufferGroupInfo();
-					AMDSErrorMon::information(this, AMDS_SERVER_INFO_BUFFER_DEF, QString("%1 definition is %2 %3 %4 %5 %6 %7").arg(i.key()).arg(oneInfo.name()).arg(oneInfo.description()).arg(oneInfo.units()).arg(oneInfo.size().toString()).arg(oneInfo.flattenEnabled()?"true":"false").arg(oneInfo.flattenMethod()));
+					AMDSErrorMon::information(this, AMDS_SERVER_INFO_BUFFER_DEF, QString("%1 definition is %2 %3 %4 %5 %6 %7").arg(i.key()).arg(oneInfo.name()).arg(oneInfo.description()).arg(oneInfo.units()).arg(oneInfo.size().toString()).arg(oneInfo.isFlattenEnabled()?"true":"false").arg(oneInfo.flattenMethod()));
 					clientIntrospectionRequest->appendBufferGroupInfo(oneInfo);
 					++i;
 				}
@@ -136,19 +136,19 @@ void AMDSCentralServer::initializeBufferGroup(quint64 maxCountSize)
 	QList<AMDSAxisInfo> mcpBufferGroupAxes;
 	mcpBufferGroupAxes << AMDSAxisInfo("X", 1024, "X Axis", "pixel");
 	mcpBufferGroupAxes << AMDSAxisInfo("Y", 512, "Y Axis", "pixel");
-	AMDSBufferGroupInfo mcpBufferGroupInfo("AFakeMCP", "Fake MCP Image", "Counts", false, AMDSBufferGroupInfo::NoFlatten, mcpBufferGroupAxes);
+	AMDSBufferGroupInfo mcpBufferGroupInfo("AFakeMCP", "Fake MCP Image", "Counts", AMDSBufferGroupInfo::NoFlatten, mcpBufferGroupAxes);
 	AMDSBufferGroup *mcpBufferGroup = new AMDSBufferGroup(mcpBufferGroupInfo, maxCountSize);
 	AMDSThreadedBufferGroup *mcpThreadedBufferGroup = new AMDSThreadedBufferGroup(mcpBufferGroup);
 	bufferGroups_.insert(mcpThreadedBufferGroup->bufferGroupInfo().name(), mcpThreadedBufferGroup);
 
 	QList<AMDSAxisInfo> amptek1BufferGroupAxes;
 	amptek1BufferGroupAxes << AMDSAxisInfo("Energy", 1024, "Energy Axis", "eV");
-	AMDSBufferGroupInfo amptek1BufferGroupInfo("Amptek1", "Amptek 1", "Counts", false, AMDSBufferGroupInfo::NoFlatten, amptek1BufferGroupAxes);
+	AMDSBufferGroupInfo amptek1BufferGroupInfo("Amptek1", "Amptek 1", "Counts", AMDSBufferGroupInfo::NoFlatten, amptek1BufferGroupAxes);
 	amptek1BufferGroup_ = new AMDSBufferGroup(amptek1BufferGroupInfo, maxCountSize);
 	AMDSThreadedBufferGroup *amptek1ThreadedBufferGroup = new AMDSThreadedBufferGroup(amptek1BufferGroup_);
 	bufferGroups_.insert(amptek1ThreadedBufferGroup->bufferGroupInfo().name(), amptek1ThreadedBufferGroup);
 
-	AMDSBufferGroupInfo energyBufferGroupInfo("Energy", "SGM Beamline Energy", "eV", true, AMDSBufferGroupInfo::Average);
+	AMDSBufferGroupInfo energyBufferGroupInfo("Energy", "SGM Beamline Energy", "eV", AMDSBufferGroupInfo::Average);
 	energyBufferGroup_ = new AMDSBufferGroup(energyBufferGroupInfo, maxCountSize);
 	AMDSThreadedBufferGroup *energyThreadedBufferGroup = new AMDSThreadedBufferGroup(energyBufferGroup_);
 	bufferGroups_.insert(energyThreadedBufferGroup->bufferGroupInfo().name(), energyThreadedBufferGroup);

--- a/source/AMDSCentralServer.cpp
+++ b/source/AMDSCentralServer.cpp
@@ -143,7 +143,7 @@ void AMDSCentralServer::initializeBufferGroup(quint64 maxCountSize)
 
 	QList<AMDSAxisInfo> amptek1BufferGroupAxes;
 	amptek1BufferGroupAxes << AMDSAxisInfo("Energy", 1024, "Energy Axis", "eV");
-	AMDSBufferGroupInfo amptek1BufferGroupInfo("Amptek1", "Amptek 1", "Counts", AMDSBufferGroupInfo::NoFlatten, amptek1BufferGroupAxes);
+	AMDSBufferGroupInfo amptek1BufferGroupInfo("Amptek1", "Amptek 1", "Counts", AMDSBufferGroupInfo::Summary, amptek1BufferGroupAxes);
 	amptek1BufferGroup_ = new AMDSBufferGroup(amptek1BufferGroupInfo, maxCountSize);
 	AMDSThreadedBufferGroup *amptek1ThreadedBufferGroup = new AMDSThreadedBufferGroup(amptek1BufferGroup_);
 	bufferGroups_.insert(amptek1ThreadedBufferGroup->bufferGroupInfo().name(), amptek1ThreadedBufferGroup);

--- a/source/AMDSClientUi.cpp
+++ b/source/AMDSClientUi.cpp
@@ -148,6 +148,7 @@ AMDSClientUi::~AMDSClientUi()
 	disconnect(clientAppController_, SIGNAL(requestDataReady(AMDSClientRequest*)), this, SLOT(onRequestDataReady(AMDSClientRequest*)));
 
 	clientAppController_->deleteLater();
+	clientAppController_ = 0;
 }
 
 void AMDSClientUi::connectToServer()

--- a/source/ClientRequest/AMDSClientDataRequest.cpp
+++ b/source/ClientRequest/AMDSClientDataRequest.cpp
@@ -27,6 +27,7 @@ AMDSClientDataRequest::AMDSClientDataRequest(const QString &socketKey, const QSt
 
 AMDSClientDataRequest::~AMDSClientDataRequest()
 {
+	clearData();
 }
 
 AMDSClientDataRequest::AMDSClientDataRequest(const AMDSClientDataRequest &other) :
@@ -49,9 +50,25 @@ AMDSClientDataRequest& AMDSClientDataRequest::operator =(const AMDSClientDataReq
 		uniformDataType_ = other.uniformDataType();
 		clearData();
 		for(int x = 0, size = other.data().count(); x < size; x++)
-			appendData(other.data().at(x));
+			copyAndAppendData(other.data().at(x));
 	}
 	return (*this);
+}
+
+void AMDSClientDataRequest::copyAndAppendData(AMDSDataHolder *dataHolder)
+{
+	AMDSDataHolder *cloneDataHolder = AMDSDataHolderSupport::instantiateDataHolderFromInstance(dataHolder);
+	(*cloneDataHolder) = (*dataHolder);
+
+	data_.append(cloneDataHolder);
+}
+
+void AMDSClientDataRequest::clearData()
+{
+	foreach(AMDSDataHolder *dataHolder, data_) {
+		dataHolder->deleteLater();
+	}
+	data_.clear();
 }
 
 int AMDSClientDataRequest::writeToDataStream(AMDSDataStream *dataStream) const

--- a/source/ClientRequest/AMDSClientDataRequest.h
+++ b/source/ClientRequest/AMDSClientDataRequest.h
@@ -3,8 +3,10 @@
 
 #include "source/ClientRequest/AMDSClientRequest.h"
 #include "source/DataElement/AMDSDataTypeDefinitions.h"
+#include "source/DataHolder/AMDSDataHolder.h"
+#include "source/DataHolder/AMDSDataHolderSupport.h"
 
-class AMDSDataHolder;
+//class AMDSDataHolder;
 
 class AMDSClientDataRequest : public AMDSClientRequest
 {
@@ -46,9 +48,9 @@ public:
 	/// Sets the uniform data type
 	inline void setUniformDataType(AMDSDataTypeDefinitions::DataType uniformDataType) { uniformDataType_ = uniformDataType; }
 	/// Adds some data to the list of data holders
-	inline void appendData(AMDSDataHolder *dataHolder) { data_.append(dataHolder); }
+	void copyAndAppendData(AMDSDataHolder *dataHolder) ;
 	/// Clears the list of data holders
-	inline void clearData() { data_.clear(); }
+	void clearData();
 
 	/// Writes this AMDSClienDatatRequest to an AMDSDataStream, returns 0 if no errors are encountered
 	virtual int writeToDataStream(AMDSDataStream *dataStream) const;

--- a/source/Connection/AMDSThreadedTCPDataServer.cpp
+++ b/source/Connection/AMDSThreadedTCPDataServer.cpp
@@ -23,7 +23,10 @@ AMDSThreadedTCPDataServer::~AMDSThreadedTCPDataServer()
 		thread_->quit();
 
 	server_->deleteLater();
+	server_ = 0;
+
 	thread_->deleteLater();
+	thread_ = 0;
 }
 
 AMDSTCPDataServer* AMDSThreadedTCPDataServer::server()

--- a/source/DataElement/AMDSAxisInfo.cpp
+++ b/source/DataElement/AMDSAxisInfo.cpp
@@ -2,14 +2,24 @@
 
 AMDSAxisInfo::AMDSAxisInfo(const QString &name, quint32 size, const QString &description, const QString &units, bool isUniform)
 {
-	name_ = name;
-	size_ = size;
-	description_ = description;
-	units_ = units;
-	isUniform_ = isUniform;
+	setName(name);
+	setSize(size);
+	setDescription(description);
+	setUnits(units);
+	setIsUniform(isUniform);
+	setStart(0);
+	setIncrement(1);
+}
 
-	start_ = 0;
-	increment_ = 1;
+AMDSAxisInfo::AMDSAxisInfo(const AMDSAxisInfo &axisInfo )
+{
+	setName(axisInfo.name());
+	setSize(axisInfo.size());
+	setDescription(axisInfo.description());
+	setUnits(axisInfo.units());
+	setIsUniform(axisInfo.isUniform());
+	setStart(axisInfo.start());
+	setIncrement(axisInfo.increment());
 }
 
 AMDSAxisInfo::~AMDSAxisInfo()

--- a/source/DataElement/AMDSAxisInfo.h
+++ b/source/DataElement/AMDSAxisInfo.h
@@ -9,6 +9,7 @@ class AMDSAxisInfo
 public:
 	/// Constructor.
 	AMDSAxisInfo(const QString& name, quint32 size, const QString& description = QString(), const QString& units = QString(), bool isUniform = true );
+	AMDSAxisInfo(const AMDSAxisInfo &axisInfo );
 	/// Destructor.
 	virtual ~AMDSAxisInfo();
 

--- a/source/DataElement/AMDSBufferGroup.cpp
+++ b/source/DataElement/AMDSBufferGroup.cpp
@@ -68,37 +68,48 @@ void AMDSBufferGroup::processClientRequest(AMDSClientRequest *clientRequest){
 	emit clientRequestProcessed(clientRequest);
 }
 
-void AMDSBufferGroup::flattenData(QList<AMDSDataHolder *> *dataArray)
+bool AMDSBufferGroup::flattenData(QList<AMDSDataHolder *> *dataArray)
 {
-	if (!bufferGroupInfo_.flattenEnabled() || bufferGroupInfo_.flattenMethod() == AMDSBufferGroupInfo::NoFlatten) {
+	if (!bufferGroupInfo_.isFlattenEnabled() || bufferGroupInfo_.flattenMethod() == AMDSBufferGroupInfo::NoFlatten) {
 		AMDSErrorMon::alert(this, AMDS_SERVER_ALT_BUFFER_GROUP_DISABLE_FLATTEN, QString("The given buffergroup (%1) doesn't enable flatten feature or the flatten method is %2.").arg(bufferGroupInfo_.name()).arg(bufferGroupInfo_.flattenMethod()));
-		return;
+		return false;
 	}
 
 	// make the summarization operation
 	int totalDataSize = dataArray->size();
-	AMDSDataHolder *flattenDataHolder = dataArray->at(0);
-	for (int i = 1; i < totalDataSize; i++) {
-		AMDSDataHolder * dataHolder = dataArray->at(i);
-		if (flattenDataHolder && dataHolder) {
-			flattenDataHolder = (*flattenDataHolder) + (*dataHolder);
+	if (totalDataSize > 0) {
+		// make a copy of the first data holder
+		AMDSDataHolder *flattenDataHolder = AMDSDataHolderSupport::instantiateDataHolderFromInstance( dataArray->at(0) );
+		(*flattenDataHolder) = (*dataArray->at(0));
+		for (int i = 1; i < totalDataSize; i++) {
+			AMDSDataHolder * dataHolder = dataArray->at(i);
+			if (flattenDataHolder && dataHolder) {
+				AMDSDataHolder *tempDataHolder = flattenDataHolder;
+				flattenDataHolder = (*flattenDataHolder) + (*dataHolder);
+				tempDataHolder->deleteLater();
+			}
 		}
+
+		if (flattenDataHolder) {
+			switch (bufferGroupInfo_.flattenMethod()) {
+			case AMDSBufferGroupInfo::Summary:
+				break; // do nothing, since we already summrized the data
+			case AMDSBufferGroupInfo::Average: {
+				AMDSDataHolder *tempDataHolder = flattenDataHolder;
+				flattenDataHolder = (*flattenDataHolder) / totalDataSize;
+				tempDataHolder->deleteLater();
+				break;
+			}
+			default:
+				break;
+			}
+		}
+
+		dataArray->clear();
+		dataArray->append(flattenDataHolder);
 	}
 
-	if (flattenDataHolder) {
-		switch (bufferGroupInfo_.flattenMethod()) {
-		case AMDSBufferGroupInfo::Summary:
-			break; // do nothing, since we already summrized the data
-		case AMDSBufferGroupInfo::Average:
-			flattenDataHolder = (*flattenDataHolder) / totalDataSize;
-			break;
-		default:
-			break;
-		}
-	}
-
-	dataArray->clear();
-	dataArray->append(flattenDataHolder);
+	return true;
 }
 
 void AMDSBufferGroup::populateData(AMDSClientDataRequest* clientDataRequest, int startIndex, int endIndex)
@@ -119,12 +130,22 @@ void AMDSBufferGroup::populateData(AMDSClientDataRequest* clientDataRequest, int
 		targetDataArray.append(dataHolder);
 	}
 
+	// when doing flattening, the data holders in the targetDataArray are new instances, which need to be released after usage
+	// if not, the array hosts original data holder, which should NOT be released
+	bool releaseDataHolders = false;
 	if (clientDataRequest->flattenResultData()) {
-		flattenData(&targetDataArray);
+		releaseDataHolders = flattenData(&targetDataArray);
 	}
 
 	foreach (AMDSDataHolder * dataHolder, targetDataArray) {
-		clientDataRequest->appendData(dataHolder);
+		clientDataRequest->copyAndAppendData(dataHolder);
+	}
+
+	if (releaseDataHolders) {
+		foreach (AMDSDataHolder *dataHolder, targetDataArray) {
+			dataHolder->deleteLater();
+		}
+		targetDataArray.clear();
 	}
 }
 

--- a/source/DataElement/AMDSBufferGroup.h
+++ b/source/DataElement/AMDSBufferGroup.h
@@ -60,8 +60,8 @@ signals:
 protected:
 	/// Helper functions which populate request data based on the parameters passed:
 
-	/// Flatten the data based on the given flatten method
-	void flattenData(QList<AMDSDataHolder *> *dataArray);
+	/// Flatten the data based on the given flatten method, return True if no error happened
+	bool flattenData(QList<AMDSDataHolder *> *dataArray);
 	/// Fills the data to the clientRequest
 	void populateData(AMDSClientDataRequest* clientDataRequest, int startIndex, int endIndex);
 	/// Fills the request with count number of spectra after (and including) startTime

--- a/source/DataElement/AMDSBufferGroupInfo.cpp
+++ b/source/DataElement/AMDSBufferGroupInfo.cpp
@@ -1,11 +1,10 @@
 #include "AMDSBufferGroupInfo.h"
 
-AMDSBufferGroupInfo::AMDSBufferGroupInfo(const QString &name, const QString &description, const QString &units, const bool flattenEnabled, const DataFlattenMethod flattenMethod, const QList<AMDSAxisInfo> &axes)
+AMDSBufferGroupInfo::AMDSBufferGroupInfo(const QString &name, const QString &description, const QString &units, const DataFlattenMethod flattenMethod, const QList<AMDSAxisInfo> &axes)
 {
 	setName(name);
 	setDescription(description);
 	setUnits(units);
-	setFlattenEnabled(flattenEnabled);
 	setFlattenMethod(flattenMethod);
 	setAxes(axes);
 }
@@ -19,7 +18,6 @@ AMDSBufferGroupInfo& AMDSBufferGroupInfo::operator=(const AMDSBufferGroupInfo& o
 	setName(other.name());
 	setDescription(other.description());
 	setUnits(other.units());
-	setFlattenEnabled(other.flattenEnabled());
 	setFlattenMethod(other.flattenMethod());
 	setAxes(other.axes());
 
@@ -28,7 +26,23 @@ AMDSBufferGroupInfo& AMDSBufferGroupInfo::operator=(const AMDSBufferGroupInfo& o
 
 QString AMDSBufferGroupInfo::toString()
 {
-	QString bufferGroupInfoDef = QString("%1 %2 %3 %4 %5 %6 %7").arg(name()).arg(description()).arg(units()).arg(rank()).arg(size().toString()).arg(flattenEnabled()?"true":"false").arg(flattenMethod());
+	QString flattenMethodStr;
+	switch(flattenMethod()) {
+	case Average:
+		flattenMethodStr = "Average";
+		break;
+	case Summary:
+		flattenMethodStr = "Summary";
+		break;
+	case NoFlatten:
+		flattenMethodStr = "NoFlatten";
+		break;
+	default:
+		flattenMethodStr = "Unknown";
+		break;
+	}
+
+	QString bufferGroupInfoDef = QString("%1 %2 %3 %4 %5 %6").arg(name()).arg(description()).arg(units()).arg(rank()).arg(size().toString()).arg(flattenMethodStr);
 
 	for(int x = 0, size = axes().count(); x < size; x++){
 		AMDSAxisInfo axisInfo = axes().at(x);

--- a/source/DataElement/AMDSBufferGroupInfo.h
+++ b/source/DataElement/AMDSBufferGroupInfo.h
@@ -16,7 +16,7 @@ public:
 		NoFlatten = 2
 	};
 
-	AMDSBufferGroupInfo(const QString& name = QString(), const QString& description = QString(), const QString& units = QString(), const bool flattenEnabled=false, const DataFlattenMethod flattenMethod=AMDSBufferGroupInfo::NoFlatten, const QList<AMDSAxisInfo>& axes = QList<AMDSAxisInfo>());
+	AMDSBufferGroupInfo(const QString& name = QString(), const QString& description = QString(), const QString& units = QString(), const DataFlattenMethod flattenMethod=AMDSBufferGroupInfo::NoFlatten, const QList<AMDSAxisInfo>& axes = QList<AMDSAxisInfo>());
 	/// Copy constructor
 	AMDSBufferGroupInfo(const AMDSBufferGroupInfo& other);
 	/// Assignment operator
@@ -29,7 +29,7 @@ public:
 	/// returns the units of the bufferGroupInfo
 	inline QString units() const { return units_; }
 	/// returns whether the bufferGroup is enabled flatten
-	inline bool flattenEnabled() const { return flattenEnabled_; }
+	inline bool isFlattenEnabled() const { return flattenMethod_ != NoFlatten; }
 	/// returns the flatten method of the bufferGroup
 	inline DataFlattenMethod flattenMethod()const { return flattenMethod_; }
 
@@ -56,8 +56,6 @@ public:
 	void setUnits(const QString &units) { units_ = units; }
 	/// Set the axes of the bufferGroupInfo
 	void setAxes(const QList<AMDSAxisInfo> &axes) { axes_ = axes; }
-	/// Set whether the bufferGroup can be flattened
-	void setFlattenEnabled(bool enabled) { flattenEnabled_ = enabled; }
 	/// Set how the bufferGroup should be flattened
 	void setFlattenMethod(DataFlattenMethod method) { flattenMethod_ = method; }
 
@@ -74,8 +72,6 @@ protected:
 	QString description_;
 	/// the unit of the bufferGroupInfo
 	QString units_;
-	/// the flag whether this buffer group allows to flatten data
-	bool flattenEnabled_;
 	/// the definition on how the data should be flattened
 	DataFlattenMethod flattenMethod_;
 

--- a/source/DataElement/AMDSEventData.cpp
+++ b/source/DataElement/AMDSEventData.cpp
@@ -96,10 +96,10 @@ void AMDSFullEventData::cloneData(AMDSEventData *sourceEventData)
 		if (lightWeightEventData_)
 			lightWeightEventData_->deleteLater();
 
-		AMDSEventData *newEventData = AMDSEventDataSupport::instantiateEventDataFromInstance(sourceFullEventData->lightWeightEventData_);
+		AMDSEventData *newEventData = AMDSEventDataSupport::instantiateEventDataFromInstance(sourceFullEventData->lightWeightEventData());
 		lightWeightEventData_ = qobject_cast<AMDSLightWeightEventData *>(newEventData);
 		if (lightWeightEventData_)
-			(*lightWeightEventData_) = (*sourceFullEventData->lightWeightEventData_);
+			(*lightWeightEventData_) = (*sourceFullEventData->lightWeightEventData());
 
 		setEventType(sourceFullEventData->eventType());
 		setTimeScale(sourceFullEventData->timeScale());

--- a/source/DataElement/AMDSEventData.cpp
+++ b/source/DataElement/AMDSEventData.cpp
@@ -114,15 +114,6 @@ void AMDSFullEventData::cloneData(AMDSEventData *sourceEventData)
 	}
 }
 
-//AMDSFullEventData& AMDSFullEventData::operator =(AMDSFullEventData &sourceEventData)
-//{
-//	if (this != &sourceEventData) {
-//		cloneData(&sourceEventData);
-//	}
-
-//	return *this;
-//}
-
 bool AMDSFullEventData::writeToDataStream(AMDSDataStream *dataStream) const{
 	if(!lightWeightEventData_->writeToDataStream(dataStream))
 		return false;

--- a/source/DataElement/AMDSEventData.cpp
+++ b/source/DataElement/AMDSEventData.cpp
@@ -44,15 +44,6 @@ void AMDSLightWeightEventData::cloneData(AMDSEventData *sourceEventData)
 	setEventTime(sourceEventData->eventTime());
 }
 
-//AMDSLightWeightEventData& AMDSLightWeightEventData::operator =(AMDSLightWeightEventData &sourceEventData)
-//{
-//	if (this != &sourceEventData) {
-//		cloneData(&sourceEventData);
-//	}
-
-//	return *this;
-//}
-
 bool AMDSLightWeightEventData::writeToDataStream(AMDSDataStream *dataStream) const{
 	*dataStream << eventTime_;
 	if(dataStream->status() != QDataStream::Ok)

--- a/source/DataElement/AMDSEventData.cpp
+++ b/source/DataElement/AMDSEventData.cpp
@@ -83,8 +83,10 @@ AMDSFullEventData::AMDSFullEventData(AMDSFullEventData &eventData, QObject *pare
 
 AMDSFullEventData::~AMDSFullEventData()
 {
-	if (lightWeightEventData_)
+	if (lightWeightEventData_) {
 		lightWeightEventData_->deleteLater();
+		lightWeightEventData_ = 0;
+	}
 }
 
 void AMDSFullEventData::cloneData(AMDSEventData *sourceEventData)
@@ -123,9 +125,12 @@ bool AMDSFullEventData::writeToDataStream(AMDSDataStream *dataStream) const{
 }
 
 bool AMDSFullEventData::readFromDataStream(AMDSDataStream *dataStream){
-	if (lightWeightEventData_)
+	if (lightWeightEventData_) {
 		lightWeightEventData_->deleteLater();
+	}
 
+	AMDSEventData *newEventData = AMDSEventDataSupport::instantiateEventDataFromClassName(AMDSLightWeightEventData::staticMetaObject.className());
+	lightWeightEventData_ = qobject_cast<AMDSLightWeightEventData *>(newEventData);
 	if(!lightWeightEventData_->readFromDataStream(dataStream))
 		return false;
 

--- a/source/DataElement/AMDSEventData.h
+++ b/source/DataElement/AMDSEventData.h
@@ -72,8 +72,6 @@ public:
 
 	/// implement the function to copy the data of the source eventData to the current instance
 	virtual void cloneData(AMDSEventData *sourceEventData);
-//	/// implementationt the function to copy the data of the source eventData to the target instance
-//	virtual AMDSLightWeightEventData& operator =(AMDSLightWeightEventData &sourceEventData);
 
 	/// Writes this AMDSEventData to an AMDSDataStream, returns true if no errors are encountered
 	virtual bool writeToDataStream(AMDSDataStream *dataStream) const;
@@ -109,6 +107,11 @@ public:
 	virtual bool writeToDataStream(AMDSDataStream *dataStream) const;
 	/// Reads this AMDSEventData from the AMDSDataStream, returns true if no errors are encountered
 	virtual bool readFromDataStream(AMDSDataStream *dataStream);
+
+protected:
+	/// getter function to get the lightWeightEventData_ of AMDSFullEventData.
+	/// The reason to encapsulate this as protected is that the user of AMDSFullEventData should NOT be aware the existence of the instance of lightWeightEventData_
+	inline AMDSLightWeightEventData * lightWeightEventData() { return lightWeightEventData_; }
 
 protected:
 	AMDSLightWeightEventData *lightWeightEventData_;

--- a/source/DataElement/AMDSEventData.h
+++ b/source/DataElement/AMDSEventData.h
@@ -41,6 +41,11 @@ public:
 	virtual inline bool setTimeScale(AMDSEventData::TimeScale timeScale) = 0;
 	virtual inline bool setTimeUncertainty(quint16 timeUncertainty) = 0;
 
+	/// virtual function to copy the data of the source eventData to the current instance
+	virtual void cloneData(AMDSEventData *sourceEventData) = 0;
+	/// implementationt the function to copy the data of the source eventData to the target instance
+	virtual AMDSEventData& operator =(AMDSEventData &sourceEventData);
+
 	/// Writes this AMDSEventData to an AMDSDataStream, returns true if no errors are encountered
 	virtual bool writeToDataStream(AMDSDataStream *dataStream) const = 0;
 	/// Reads this AMDSEventData from the AMDSDataStream, returns true if no errors are encountered
@@ -52,6 +57,7 @@ class AMDSLightWeightEventData : public AMDSEventData
 Q_OBJECT
 public:
 	Q_INVOKABLE AMDSLightWeightEventData(QDateTime eventTime = QDateTime::currentDateTime(), QObject *parent = 0);
+	Q_INVOKABLE AMDSLightWeightEventData(AMDSLightWeightEventData &eventData, QObject *parent = 0);
 	virtual ~AMDSLightWeightEventData();
 
 	virtual QDateTime eventTime() const { return eventTime_; }
@@ -63,6 +69,11 @@ public:
 	virtual inline bool setEventType(AMDSEventData::EventType eventType);
 	virtual inline bool setTimeScale(AMDSEventData::TimeScale timeScale);
 	virtual inline bool setTimeUncertainty(quint16 timeUncertainty);
+
+	/// implement the function to copy the data of the source eventData to the current instance
+	virtual void cloneData(AMDSEventData *sourceEventData);
+//	/// implementationt the function to copy the data of the source eventData to the target instance
+//	virtual AMDSLightWeightEventData& operator =(AMDSLightWeightEventData &sourceEventData);
 
 	/// Writes this AMDSEventData to an AMDSDataStream, returns true if no errors are encountered
 	virtual bool writeToDataStream(AMDSDataStream *dataStream) const;
@@ -78,6 +89,7 @@ class AMDSFullEventData : public AMDSEventData
 Q_OBJECT
 public:
 	Q_INVOKABLE AMDSFullEventData(QDateTime eventTime = QDateTime::currentDateTime(), AMDSEventData::EventType eventType = AMDSEventData::SingleEvent, AMDSEventData::TimeScale timeScale = AMDSEventData::SecondsScale, quint16 timeUncertainty = 0, QObject *parent = 0);
+	Q_INVOKABLE AMDSFullEventData(AMDSFullEventData &eventData, QObject *parent = 0);
 	virtual ~AMDSFullEventData();
 
 	virtual QDateTime eventTime() const { return lightWeightEventData_->eventTime(); }
@@ -89,6 +101,11 @@ public:
 	virtual inline bool setEventType(AMDSEventData::EventType eventType);
 	virtual inline bool setTimeScale(AMDSEventData::TimeScale timeScale);
 	virtual inline bool setTimeUncertainty(quint16 timeUncertainty);
+
+	/// implement the function to copy the data of the source eventData to the current instance
+	virtual void cloneData(AMDSEventData *sourceEventData);
+//	/// implementationt the function to copy the data of the source eventData to the target instance
+//	virtual AMDSFullEventData& operator =(AMDSFullEventData &sourceEventData);
 
 	/// Writes this AMDSEventData to an AMDSDataStream, returns true if no errors are encountered
 	virtual bool writeToDataStream(AMDSDataStream *dataStream) const;

--- a/source/DataElement/AMDSEventData.h
+++ b/source/DataElement/AMDSEventData.h
@@ -104,8 +104,6 @@ public:
 
 	/// implement the function to copy the data of the source eventData to the current instance
 	virtual void cloneData(AMDSEventData *sourceEventData);
-//	/// implementationt the function to copy the data of the source eventData to the target instance
-//	virtual AMDSFullEventData& operator =(AMDSFullEventData &sourceEventData);
 
 	/// Writes this AMDSEventData to an AMDSDataStream, returns true if no errors are encountered
 	virtual bool writeToDataStream(AMDSDataStream *dataStream) const;

--- a/source/DataElement/AMDSEventDataSupport.cpp
+++ b/source/DataElement/AMDSEventDataSupport.cpp
@@ -41,6 +41,8 @@ namespace AMDSEventDataSupport{
 	{
 		if(!AMDSEventDataSupport::registeredClasses()->contains(AMDSLightWeightEventData::staticMetaObject.className()))
 			AMDSEventDataSupport::registerClass<AMDSLightWeightEventData>();
+		if(!AMDSEventDataSupport::registeredClasses()->contains(AMDSFullEventData::staticMetaObject.className()))
+			AMDSEventDataSupport::registerClass<AMDSFullEventData>();
 	}
 
 	const QHash<QString, AMDSEventDataObjectInfo>* registeredClasses() {
@@ -54,6 +56,13 @@ namespace AMDSEventDataSupport{
 				return eventData;
 		}
 		return 0;
+	}
+
+	AMDSEventData* instantiateEventDataFromInstance(const AMDSEventData *instance){
+		if (instance)
+			return instantiateEventDataFromClassName(instance->metaObject()->className());
+		else
+			return 0;
 	}
 
 	bool inheritsEventData(const QMetaObject *queryMetaObject){

--- a/source/DataElement/AMDSEventDataSupport.h
+++ b/source/DataElement/AMDSEventDataSupport.h
@@ -46,6 +46,7 @@ namespace AMDSEventDataSupport {
 	const QHash<QString, AMDSEventDataObjectInfo>* registeredClasses();
 
 	AMDSEventData* instantiateEventDataFromClassName(const QString &className);
+	AMDSEventData* instantiateEventDataFromInstance(const AMDSEventData *instance);
 
 	bool inheritsEventData(const QMetaObject *queryMetaObject);
 

--- a/source/DataElement/AMDSFlatArray.cpp
+++ b/source/DataElement/AMDSFlatArray.cpp
@@ -8,6 +8,7 @@ AMDSFlatArray::AMDSFlatArray(AMDSDataTypeDefinitions::DataType dataType, quint32
 
 AMDSFlatArray::~AMDSFlatArray()
 {
+	clear();
 }
 
 AMDSFlatArray AMDSFlatArray::operator +(AMDSFlatArray &dataFlatArray)

--- a/source/DataElement/AMDSFlatArray.h
+++ b/source/DataElement/AMDSFlatArray.h
@@ -2,6 +2,7 @@
 #define AMDSFLATARRAY_H
 
 #include <QVector>
+#include <QString>
 
 #include "source/DataElement/AMDSDataTypeDefinitions.h"
 

--- a/source/DataHolder/AMDSDataHolder.cpp
+++ b/source/DataHolder/AMDSDataHolder.cpp
@@ -39,8 +39,10 @@ AMDSLightWeightDataHolder::AMDSLightWeightDataHolder(AMDSLightWeightDataHolder &
 
 AMDSLightWeightDataHolder::~AMDSLightWeightDataHolder()
 {
-	if (eventData_)
+	if (eventData_) {
 		eventData_->deleteLater();
+		eventData_ = 0;
+	}
 }
 
 AMDSDataTypeDefinitions::DataType AMDSLightWeightDataHolder::dataType() const{
@@ -102,8 +104,10 @@ AMDSFullDataHolder::AMDSFullDataHolder(AMDSFullDataHolder &sourceFullDataHolder,
 
 AMDSFullDataHolder::~AMDSFullDataHolder()
 {
-	if (lightWeightDataHolder_)
+	if (lightWeightDataHolder_) {
 		lightWeightDataHolder_->deleteLater();
+		lightWeightDataHolder_ = 0;
+	}
 
 	axes_.clear();
 }

--- a/source/DataHolder/AMDSDataHolder.cpp
+++ b/source/DataHolder/AMDSDataHolder.cpp
@@ -62,7 +62,7 @@ void AMDSLightWeightDataHolder::cloneData(AMDSDataHolder *sourceDataHolder)
 			eventData_->deleteLater();
 
 		eventData_ = AMDSEventDataSupport::instantiateEventDataFromInstance(sourceLightWeightDataHolder->eventData());
-		(*eventData_) = *(sourceLightWeightDataHolder->eventData_); // copy the values of the eventData over
+		(*eventData_) = *(sourceLightWeightDataHolder->eventData()); // copy the values of the eventData over
 	}
 }
 

--- a/source/DataHolder/AMDSDataHolder.cpp
+++ b/source/DataHolder/AMDSDataHolder.cpp
@@ -64,19 +64,6 @@ void AMDSLightWeightDataHolder::cloneData(AMDSDataHolder *sourceDataHolder)
 	}
 }
 
-//AMDSLightWeightDataHolder& AMDSLightWeightDataHolder::operator =(const AMDSLightWeightDataHolder &sourceDataHolder)
-//{
-//	if(this != &sourceDataHolder){
-//		if (eventData_)
-//			eventData_->deleteLater();
-
-//		eventData_ = AMDSEventDataSupport::instantiateEventDataFromInstance(sourceDataHolder.eventData());
-//		(*eventData_) = *(sourceDataHolder.eventData_); // copy the values of the eventData over
-//	}
-
-//	return (*this);
-//}
-
 bool AMDSLightWeightDataHolder::writeToDataStream(AMDSDataStream *dataStream, bool encodeDataType) const{
 	Q_UNUSED(encodeDataType)
 	dataStream->encodeEventDataType(*eventData_);
@@ -151,34 +138,6 @@ void AMDSFullDataHolder::cloneData(AMDSDataHolder *sourceDataHolder)
 		dataTypeStyle_ = sourceFullDataHolder->dataTypeStyle();
 	}
 }
-
-//AMDSFullDataHolder& AMDSFullDataHolder::operator =(const AMDSFullDataHolder &sourceDataHolder)
-//{
-//	if(this != &sourceDataHolder){
-//		if (lightWeightDataHolder_)
-//			lightWeightDataHolder_->deleteLater();
-
-////			foreach (AMDSAxisInfo axisInfo, axes_) {
-////				axes_.removeOne(axisInfo);
-////				delete &axisInfo;
-////			}
-//			axes_.clear();
-
-//		AMDSDataHolder *newDataHolder = AMDSDataHolderSupport::instantiateDataHolderFromInstance(sourceDataHolder.lightWeightDataHolder_);
-//		lightWeightDataHolder_ = qobject_cast<AMDSLightWeightDataHolder *>(newDataHolder);
-//		(*lightWeightDataHolder_) = (*sourceDataHolder.lightWeightDataHolder_);
-
-//		foreach (AMDSAxisInfo axisInfo, sourceDataHolder.axes()) {
-//			AMDSAxisInfo copyAxisInfo(axisInfo);
-//			axes_.append(copyAxisInfo);
-//		}
-
-//		axesStyle_ = sourceDataHolder.axesStyle();
-//		dataTypeStyle_ = sourceDataHolder.dataTypeStyle();
-//	}
-
-//	return (*this);
-//}
 
 bool AMDSFullDataHolder::writeToDataStream(AMDSDataStream *dataStream, bool encodeDataType) const{
 	dataStream->encodeDataHolderType(*lightWeightDataHolder_);

--- a/source/DataHolder/AMDSDataHolder.cpp
+++ b/source/DataHolder/AMDSDataHolder.cpp
@@ -129,9 +129,9 @@ void AMDSFullDataHolder::cloneData(AMDSDataHolder *sourceDataHolder)
 		if (lightWeightDataHolder_)
 			lightWeightDataHolder_->deleteLater();
 
-		AMDSDataHolder *newDataHolder = AMDSDataHolderSupport::instantiateDataHolderFromInstance(sourceFullDataHolder->lightWeightDataHolder_);
+		AMDSDataHolder *newDataHolder = AMDSDataHolderSupport::instantiateDataHolderFromInstance(sourceFullDataHolder->lightWeightDataHolder());
 		lightWeightDataHolder_ = qobject_cast<AMDSLightWeightDataHolder *>(newDataHolder);
-		(*lightWeightDataHolder_) = (*sourceFullDataHolder->lightWeightDataHolder_);
+		(*lightWeightDataHolder_) = (*sourceFullDataHolder->lightWeightDataHolder());
 
 		foreach (AMDSAxisInfo axisInfo, sourceFullDataHolder->axes()) {
 			AMDSAxisInfo copyAxisInfo(axisInfo);

--- a/source/DataHolder/AMDSDataHolder.h
+++ b/source/DataHolder/AMDSDataHolder.h
@@ -121,6 +121,10 @@ public:
 	/// implement the function to read this AMDSDataHolder from the AMDSDataStream, returns true if no errors are encountered
 	virtual bool readFromDataStream(AMDSDataStream *dataStream, AMDSDataTypeDefinitions::DataType decodeAsDataType);
 
+	/// getter function to get the eventData_ of AMDSEventData.
+	/// The reason to encapsulate this as protected is that the user of AMDSEventData should NOT be aware the existence of the instance of eventData_
+	inline AMDSEventData * eventData() { return eventData_; }
+
 protected:
 	/// the instance of event data, which provides the event information about the dataHolder
 	AMDSEventData *eventData_;
@@ -185,7 +189,7 @@ public:
 protected:
 	/// getter function to get the lightweightDataHolder of AMDSFullDataHolder.
 	/// The reason to encapsulate this as protected is that the user of AMDSFullDataHolder should NOT be aware the existence of the instance of lightweightDataHolder
-	inline AMDSLightWeightDataHolder * lightWeightDataHolder() { return AMDSLightWeightDataHolder; }
+	inline AMDSLightWeightDataHolder * lightWeightDataHolder() { return lightWeightDataHolder_; }
 
 protected:
 	/// instance of AMDSLightWightDataHolder as the real holder for data

--- a/source/DataHolder/AMDSDataHolder.h
+++ b/source/DataHolder/AMDSDataHolder.h
@@ -183,6 +183,11 @@ public:
 	virtual bool readFromDataStream(AMDSDataStream *dataStream, AMDSDataTypeDefinitions::DataType decodeAsDataType);
 
 protected:
+	/// getter function to get the lightweightDataHolder of AMDSFullDataHolder.
+	/// The reason to encapsulate this as protected is that the user of AMDSFullDataHolder should NOT be aware the existence of the instance of lightweightDataHolder
+	inline AMDSLightWeightDataHolder * lightWeightDataHolder() { return AMDSLightWeightDataHolder; }
+
+protected:
 	/// instance of AMDSLightWightDataHolder as the real holder for data
 	AMDSLightWeightDataHolder *lightWeightDataHolder_;
 

--- a/source/DataHolder/AMDSDataHolder.h
+++ b/source/DataHolder/AMDSDataHolder.h
@@ -115,8 +115,6 @@ public:
 
 	/// implement the function copy the value of source instance to the current instance
 	virtual void cloneData(AMDSDataHolder *dataHolder);
-//	/// implement the = operation of AMDSDataHolder, which will copy the value of source instance to the target one
-//	virtual AMDSLightWeightDataHolder& operator =(const AMDSLightWeightDataHolder &dataHolder);
 
 	/// implement the function to write this AMDSDataHolder to an AMDSDataStream, returns true if no errors are encountered
 	virtual bool writeToDataStream(AMDSDataStream *dataStream, bool encodeDataType) const;
@@ -173,8 +171,6 @@ public:
 
 	/// implement the function copy the value of source instance to the current instance
 	virtual void cloneData(AMDSDataHolder *dataHolder);
-//	/// implement the = operation of AMDSDataHolder, which will copy the value of source instance to the target one
-//	virtual AMDSFullDataHolder& operator =(const AMDSFullDataHolder &dataHolder);
 
 	/// implement the PLUS operation of AMDSDataHolder, which will plus the value of the two instances of AMDSDataHolder and return the new instance
 	virtual AMDSDataHolder* operator +(AMDSDataHolder &dataHolder) { return lightWeightDataHolder_->operator +(dataHolder); }

--- a/source/DataHolder/AMDSDataHolder.h
+++ b/source/DataHolder/AMDSDataHolder.h
@@ -77,6 +77,11 @@ public:
 	/// pure virtual function to define the Division operation of AMDSDataHolder: the value of the given handler will be divided by the given divisior
 	virtual AMDSDataHolder* operator /(quint32 divisor) = 0;
 
+	/// pure virtual function copy the value of source instance to the current instance
+	virtual void cloneData(AMDSDataHolder *dataHolder) = 0;
+	/// implement the = operation of AMDSDataHolder, which will copy the value of source instance to the target one
+	virtual AMDSDataHolder& operator =(AMDSDataHolder &dataHolder);
+
 	/// pure virtual function to write this AMDSDataHolder to an AMDSDataStream, returns true if no errors are encountered. By default the data type is encoded into the stream; however, this can be disabled and moved to a higher level if need be.
 	virtual bool writeToDataStream(AMDSDataStream *dataStream, bool encodeDataType = true) const = 0;
 	/// pure virtual function to read this AMDSDataHolder from the AMDSDataStream, returns true if no errors are encountered. By default the data type is decoded from the stream; however, passing a particular data type will assume that there is no data type encoded in the stream.
@@ -88,6 +93,7 @@ class AMDSLightWeightDataHolder : public AMDSDataHolder
 Q_OBJECT
 public:
 	AMDSLightWeightDataHolder(QObject *parent = 0);
+	AMDSLightWeightDataHolder(AMDSLightWeightDataHolder &sourceLightWeightDataHolder, QObject *parent = 0);
 	virtual ~AMDSLightWeightDataHolder();
 
 	/// implement the axesStyle function
@@ -107,6 +113,11 @@ public:
 	virtual bool operator >(const QDateTime &rhs) { return eventData()->eventTime() > rhs; }
 	virtual bool operator ==(const QDateTime &rhs) { return eventData()->eventTime() == rhs; }
 
+	/// implement the function copy the value of source instance to the current instance
+	virtual void cloneData(AMDSDataHolder *dataHolder);
+//	/// implement the = operation of AMDSDataHolder, which will copy the value of source instance to the target one
+//	virtual AMDSLightWeightDataHolder& operator =(const AMDSLightWeightDataHolder &dataHolder);
+
 	/// implement the function to write this AMDSDataHolder to an AMDSDataStream, returns true if no errors are encountered
 	virtual bool writeToDataStream(AMDSDataStream *dataStream, bool encodeDataType) const;
 	/// implement the function to read this AMDSDataHolder from the AMDSDataStream, returns true if no errors are encountered
@@ -122,6 +133,7 @@ class AMDSFullDataHolder : public AMDSDataHolder
 Q_OBJECT
 public:
 	AMDSFullDataHolder(AMDSDataHolder::AxesStyle axesStyle, AMDSDataHolder::DataTypeStyle dataTypeStyle, const QList<AMDSAxisInfo>& axes = QList<AMDSAxisInfo>(), QObject *parent = 0);
+	AMDSFullDataHolder(AMDSFullDataHolder &sourceFullDataHolder, QObject *parent = 0);
 	virtual ~AMDSFullDataHolder();
 
 	/// implement the axesStyle() function
@@ -158,6 +170,11 @@ public:
 	virtual bool operator <(const QDateTime &rhs) { return lightWeightDataHolder_->operator <(rhs); }
 	virtual bool operator >(const QDateTime &rhs) { return lightWeightDataHolder_->operator >(rhs); }
 	virtual bool operator ==(const QDateTime &rhs) { return lightWeightDataHolder_->operator ==(rhs); }
+
+	/// implement the function copy the value of source instance to the current instance
+	virtual void cloneData(AMDSDataHolder *dataHolder);
+//	/// implement the = operation of AMDSDataHolder, which will copy the value of source instance to the target one
+//	virtual AMDSFullDataHolder& operator =(const AMDSFullDataHolder &dataHolder);
 
 	/// implement the PLUS operation of AMDSDataHolder, which will plus the value of the two instances of AMDSDataHolder and return the new instance
 	virtual AMDSDataHolder* operator +(AMDSDataHolder &dataHolder) { return lightWeightDataHolder_->operator +(dataHolder); }

--- a/source/DataHolder/AMDSDataHolderSupport.cpp
+++ b/source/DataHolder/AMDSDataHolderSupport.cpp
@@ -61,6 +61,13 @@ namespace AMDSDataHolderSupport{
 		return 0;
 	}
 
+	AMDSDataHolder* instantiateDataHolderFromInstance(const AMDSDataHolder *dataHolder){
+		if (dataHolder)
+			return instantiateDataHolderFromClassName(dataHolder->metaObject()->className());
+		else
+			return 0;
+	}
+
 	bool inheritsDataHolder(const QMetaObject *queryMetaObject){
 		const QMetaObject *dataHolderMetaObject = &(AMDSDataHolder::staticMetaObject);
 		return AMDSMetaObjectSupport::inheritsClass(queryMetaObject, dataHolderMetaObject);

--- a/source/DataHolder/AMDSDataHolderSupport.h
+++ b/source/DataHolder/AMDSDataHolderSupport.h
@@ -47,6 +47,8 @@ namespace AMDSDataHolderSupport {
 
 	/// helper function to instantiate client request from the give type
 	AMDSDataHolder* instantiateDataHolderFromClassName(const QString &className);
+	/// helper function to instantiate client request from the give instance
+	AMDSDataHolder* instantiateDataHolderFromInstance(const AMDSDataHolder *dataHolder);
 
 	bool inheritsDataHolder(const QMetaObject *queryMetaObject);
 

--- a/source/DataHolder/AMDSGenericFlatArrayDataHolder.cpp
+++ b/source/DataHolder/AMDSGenericFlatArrayDataHolder.cpp
@@ -48,7 +48,7 @@ void AMDSLightWeightGenericFlatArrayDataHolder::cloneData(AMDSDataHolder *source
 	AMDSLightWeightDataHolder::cloneData(sourceDataHolder);
 
 	AMDSLightWeightGenericFlatArrayDataHolder *sourceLightWeightGenericFlatArrayDataHolder = qobject_cast<AMDSLightWeightGenericFlatArrayDataHolder *>(sourceDataHolder);
-	sourceLightWeightGenericFlatArrayDataHolder->valueFlatArray_.resetTargetArrayAndReplaceData(&valueFlatArray_);
+	sourceLightWeightGenericFlatArrayDataHolder->dataArray().resetTargetArrayAndReplaceData(&valueFlatArray_);
 }
 
 bool AMDSLightWeightGenericFlatArrayDataHolder::writeToDataStream(AMDSDataStream *dataStream, bool encodeDataType) const{

--- a/source/DataHolder/AMDSGenericFlatArrayDataHolder.cpp
+++ b/source/DataHolder/AMDSGenericFlatArrayDataHolder.cpp
@@ -4,9 +4,15 @@
 #include "source/DataHolder/AMDSDataHolderSupport.h"
 #include "source/util/AMDSErrorMonitor.h"
 
-AMDSLightWeightGenericFlatArrayDataHolder::AMDSLightWeightGenericFlatArrayDataHolder(AMDSDataTypeDefinitions::DataType dataType, quint32 size, QObject *parent) :
-	AMDSLightWeightDataHolder(parent), valueFlatArray_(dataType, size)
+AMDSLightWeightGenericFlatArrayDataHolder::AMDSLightWeightGenericFlatArrayDataHolder(AMDSDataTypeDefinitions::DataType dataType, quint32 size, QObject *parent)
+	:AMDSLightWeightDataHolder(parent), valueFlatArray_(dataType, size)
 {
+}
+
+AMDSLightWeightGenericFlatArrayDataHolder::AMDSLightWeightGenericFlatArrayDataHolder(AMDSLightWeightGenericFlatArrayDataHolder* sourceDataHolder, QObject *parent)
+	:AMDSLightWeightDataHolder(parent), valueFlatArray_(sourceDataHolder->valueFlatArray_.dataType(), sourceDataHolder->valueFlatArray_.size())
+{
+	cloneData(sourceDataHolder);
 }
 
 AMDSLightWeightGenericFlatArrayDataHolder::~AMDSLightWeightGenericFlatArrayDataHolder()
@@ -35,6 +41,14 @@ AMDSDataHolder* AMDSLightWeightGenericFlatArrayDataHolder::operator /(const quin
 	AMDSDataHolder* targetDataHolder = AMDSDataHolderSupport::instantiateDataHolderFromClassName(metaObject()->className());
 	targetDataHolder->setData(&data);
 	return targetDataHolder;
+}
+
+void AMDSLightWeightGenericFlatArrayDataHolder::cloneData(AMDSDataHolder *sourceDataHolder)
+{
+	AMDSLightWeightDataHolder::cloneData(sourceDataHolder);
+
+	AMDSLightWeightGenericFlatArrayDataHolder *sourceLightWeightGenericFlatArrayDataHolder = qobject_cast<AMDSLightWeightGenericFlatArrayDataHolder *>(sourceDataHolder);
+	sourceLightWeightGenericFlatArrayDataHolder->valueFlatArray_.resetTargetArrayAndReplaceData(&valueFlatArray_);
 }
 
 bool AMDSLightWeightGenericFlatArrayDataHolder::writeToDataStream(AMDSDataStream *dataStream, bool encodeDataType) const{

--- a/source/DataHolder/AMDSGenericFlatArrayDataHolder.h
+++ b/source/DataHolder/AMDSGenericFlatArrayDataHolder.h
@@ -8,6 +8,7 @@ class AMDSLightWeightGenericFlatArrayDataHolder : public AMDSLightWeightDataHold
 Q_OBJECT
 public:
 	AMDSLightWeightGenericFlatArrayDataHolder(AMDSDataTypeDefinitions::DataType dataType = AMDSDataTypeDefinitions::Double, quint32 size = 2, QObject *parent = 0);
+	AMDSLightWeightGenericFlatArrayDataHolder(AMDSLightWeightGenericFlatArrayDataHolder* sourceDataHolder, QObject *parent = 0);
 	virtual ~AMDSLightWeightGenericFlatArrayDataHolder();
 
 	/// Implement the function to return the number of points this measurement spans (A scalar value is "1" point, a 1D Detector is the same as its dimension, higher-D detectors are the products of their dimensions)
@@ -25,6 +26,8 @@ public:
 	/// implement the function to return the data string
 	virtual QString printData() { return valueFlatArray_.printData(); }
 
+	/// reimplement the function copy the value of source instance to the current instance
+	virtual void cloneData(AMDSDataHolder *dataHolder);
 	/// reimplement the function to write this AMDSDataHolder to an AMDSDataStream, returns true if no errors are encountered
 	virtual bool writeToDataStream(AMDSDataStream *dataStream, bool encodeDataType) const;
 	/// reimplement the function to read this AMDSDataHolder from the AMDSDataStream, returns true if no errors are encountered

--- a/source/DataHolder/AMDSGenericFlatArrayDataHolder.h
+++ b/source/DataHolder/AMDSGenericFlatArrayDataHolder.h
@@ -22,7 +22,7 @@ public:
 	/// implement the data function to read data from valueFlatArray_ and write data to the given outputArray
 	virtual bool data(AMDSFlatArray *outputArray) const { return valueFlatArray_.resetTargetArrayAndReplaceData(outputArray); }
 	/// implement the setData function to update valueFlatArray_ with given inputArray
-	virtual void setData(AMDSFlatArray *inputArray) { inputArray->copyDataToTargetArray(&valueFlatArray_); }
+	virtual void setData(AMDSFlatArray *inputArray) { inputArray->resetTargetArrayAndReplaceData(&valueFlatArray_); }
 	/// implement the function to return the data string
 	virtual QString printData() { return valueFlatArray_.printData(); }
 

--- a/source/DataHolder/AMDSScalarDataHolder.cpp
+++ b/source/DataHolder/AMDSScalarDataHolder.cpp
@@ -8,6 +8,11 @@ AMDSLightWeightScalarDataHolder::AMDSLightWeightScalarDataHolder(AMDSDataTypeDef
 	eventData_ = new AMDSLightWeightEventData();
 }
 
+AMDSLightWeightScalarDataHolder::AMDSLightWeightScalarDataHolder(AMDSLightWeightScalarDataHolder *sourceDataHolder, QObject *parent )
+	:AMDSLightWeightGenericFlatArrayDataHolder(sourceDataHolder, parent)
+{
+}
+
 AMDSLightWeightScalarDataHolder::~AMDSLightWeightScalarDataHolder()
 {
 }

--- a/source/DataHolder/AMDSScalarDataHolder.h
+++ b/source/DataHolder/AMDSScalarDataHolder.h
@@ -8,6 +8,7 @@ class AMDSLightWeightScalarDataHolder : public AMDSLightWeightGenericFlatArrayDa
 Q_OBJECT
 public:
 	Q_INVOKABLE AMDSLightWeightScalarDataHolder(AMDSDataTypeDefinitions::DataType dataType = AMDSDataTypeDefinitions::Double, QObject *parent = 0);
+	Q_INVOKABLE AMDSLightWeightScalarDataHolder(AMDSLightWeightScalarDataHolder *sourceDataHolder, QObject *parent = 0);
 	virtual ~AMDSLightWeightScalarDataHolder();
 
 	/// implement the function to return axes information

--- a/source/DataHolder/AMDSSpectralDataHolder.cpp
+++ b/source/DataHolder/AMDSSpectralDataHolder.cpp
@@ -8,6 +8,12 @@ AMDSLightWeightSpectralDataHolder::AMDSLightWeightSpectralDataHolder(AMDSDataTyp
 	eventData_ = new AMDSLightWeightEventData();
 }
 
+AMDSLightWeightSpectralDataHolder::AMDSLightWeightSpectralDataHolder(AMDSLightWeightSpectralDataHolder *sourceDataHolder, QObject *parent)
+	:AMDSLightWeightGenericFlatArrayDataHolder(sourceDataHolder, parent)
+{
+
+}
+
 AMDSLightWeightSpectralDataHolder::~AMDSLightWeightSpectralDataHolder()
 {
 }

--- a/source/DataHolder/AMDSSpectralDataHolder.h
+++ b/source/DataHolder/AMDSSpectralDataHolder.h
@@ -8,6 +8,7 @@ class AMDSLightWeightSpectralDataHolder : public AMDSLightWeightGenericFlatArray
 Q_OBJECT
 public:
 	Q_INVOKABLE AMDSLightWeightSpectralDataHolder(AMDSDataTypeDefinitions::DataType dataType = AMDSDataTypeDefinitions::Double, quint32 size = 2, QObject *parent = 0);
+	Q_INVOKABLE AMDSLightWeightSpectralDataHolder(AMDSLightWeightSpectralDataHolder *sourceDataHolder, QObject *parent = 0);
 	virtual ~AMDSLightWeightSpectralDataHolder();
 
 	/// implement the function to return axes information

--- a/source/appController/AMDSClientAppController.cpp
+++ b/source/appController/AMDSClientAppController.cpp
@@ -36,6 +36,7 @@ AMDSClientAppController::~AMDSClientAppController()
 	if (networkSession_) {
 		disconnect(networkSession_, SIGNAL(opened()), this, SLOT(onNetworkSessionOpened()));
 		networkSession_->deleteLater();
+		networkSession_ = 0;
 	}
 }
 


### PR DESCRIPTION
https://github.com/acquaman/AcquamanDataServer/issues/67
- Add the copy/clone function for the dataModels of AMDS, which is needed when we need copy data
- For AMDSClientDataRequest, the data will be a copy of the original data instead of the pointer to the original data
- when clearing the data in AMDSClientDataRequet, we will delete the date since it is a copy now and safe to be deleted
- when doing flattening, we will delete the past +|/ result, since they are newly created instances. In this way, we will avoid memory leak
- after reflattening, we will delete the array content since they are newly "created" dataholder instance by the flatten function
