### PR TITLE
PullRequest for Issue73: fix the bug for spectra data flatten

### DIFF
--- a/source/AMDSCentralServer.cpp
+++ b/source/AMDSCentralServer.cpp
@@ -143,7 +143,7 @@ void AMDSCentralServer::initializeBufferGroup(quint64 maxCountSize)
 
 	QList<AMDSAxisInfo> amptek1BufferGroupAxes;
 	amptek1BufferGroupAxes << AMDSAxisInfo("Energy", 1024, "Energy Axis", "eV");
-	AMDSBufferGroupInfo amptek1BufferGroupInfo("Amptek1", "Amptek 1", "Counts", AMDSBufferGroupInfo::NoFlatten, amptek1BufferGroupAxes);
+	AMDSBufferGroupInfo amptek1BufferGroupInfo("Amptek1", "Amptek 1", "Counts", AMDSBufferGroupInfo::Summary, amptek1BufferGroupAxes);
 	amptek1BufferGroup_ = new AMDSBufferGroup(amptek1BufferGroupInfo, maxCountSize);
 	AMDSThreadedBufferGroup *amptek1ThreadedBufferGroup = new AMDSThreadedBufferGroup(amptek1BufferGroup_);
 	bufferGroups_.insert(amptek1ThreadedBufferGroup->bufferGroupInfo().name(), amptek1ThreadedBufferGroup);

--- a/source/DataHolder/AMDSGenericFlatArrayDataHolder.h
+++ b/source/DataHolder/AMDSGenericFlatArrayDataHolder.h
@@ -22,7 +22,7 @@ public:
 	/// implement the data function to read data from valueFlatArray_ and write data to the given outputArray
 	virtual bool data(AMDSFlatArray *outputArray) const { return valueFlatArray_.resetTargetArrayAndReplaceData(outputArray); }
 	/// implement the setData function to update valueFlatArray_ with given inputArray
-	virtual void setData(AMDSFlatArray *inputArray) { inputArray->copyDataToTargetArray(&valueFlatArray_); }
+	virtual void setData(AMDSFlatArray *inputArray) { inputArray->resetTargetArrayAndReplaceData(&valueFlatArray_); }
 	/// implement the function to return the data string
 	virtual QString printData() { return valueFlatArray_.printData(); }
 


### PR DESCRIPTION
Fix the bug to flatten the spectra data:
when we copy the data to dataHolder, we should reset the type as well.
