### PR TITLE
PullRequest for Issue1720: reimplement the constVectorDouble() function to return a double vector

### DIFF
--- a/source/DataElement/AMDSFlatArray.cpp
+++ b/source/DataElement/AMDSFlatArray.cpp
@@ -399,7 +399,7 @@ bool AMDSFlatArray::setValue(int index, double  value)
 	return true;
 }
 
-const QVector<double> AMDSFlatArray::constVectorDouble() const
+const QVector<double> AMDSFlatArray::asConstVectorDouble() const
 {
 	QVector<double> targetVector;
 	switch(dataType_){
@@ -410,42 +410,42 @@ const QVector<double> AMDSFlatArray::constVectorDouble() const
 		break;
 
 	case AMDSDataTypeDefinitions::Unsigned8:
-		foreach(quint8 value, vectorQint8_) {
+		foreach(quint8 value, vectorQuint8_) {
 			targetVector.append((double)value);
 		}
 		break;
 	case AMDSDataTypeDefinitions::Signed16:
-		foreach(qint16 value, vectorQint8_) {
+		foreach(qint16 value, vectorQint16_) {
 			targetVector.append((double)value);
 		}
 		break;
 	case AMDSDataTypeDefinitions::Unsigned16:
-		foreach(quint16 value, vectorQint8_) {
+		foreach(quint16 value, vectorQuint16_) {
 			targetVector.append((double)value);
 		}
 		break;
 	case AMDSDataTypeDefinitions::Signed32:
-		foreach(qint32 value, vectorQint8_) {
+		foreach(qint32 value, vectorQint32_) {
 			targetVector.append((double)value);
 		}
 		break;
 	case AMDSDataTypeDefinitions::Unsigned32:
-		foreach(quint32 value, vectorQint8_) {
+		foreach(quint32 value, vectorQuint32_) {
 			targetVector.append((double)value);
 		}
 		break;
 	case AMDSDataTypeDefinitions::Signed64:
-		foreach(qint64 value, vectorQint8_) {
+		foreach(qint64 value, vectorQint64_) {
 			targetVector.append((double)value);
 		}
 		break;
 	case AMDSDataTypeDefinitions::Unsigned64:
-		foreach(quint64 value, vectorQint8_) {
+		foreach(quint64 value, vectorQuint64_) {
 			targetVector.append((double)value);
 		}
 		break;
 	case AMDSDataTypeDefinitions::Float:
-		foreach(float value, vectorQint8_) {
+		foreach(float value, vectorFloat_) {
 			targetVector.append((double)value);
 		}
 		break;

--- a/source/DataElement/AMDSFlatArray.cpp
+++ b/source/DataElement/AMDSFlatArray.cpp
@@ -399,6 +399,67 @@ bool AMDSFlatArray::setValue(int index, double  value)
 	return true;
 }
 
+const QVector<double> AMDSFlatArray::constVectorDouble() const
+{
+	QVector<double> targetVector;
+	switch(dataType_){
+	case AMDSDataTypeDefinitions::Signed8:
+		foreach(qint8 value, vectorQint8_) {
+			targetVector.append((double)value);
+		}
+		break;
+
+	case AMDSDataTypeDefinitions::Unsigned8:
+		foreach(quint8 value, vectorQint8_) {
+			targetVector.append((double)value);
+		}
+		break;
+	case AMDSDataTypeDefinitions::Signed16:
+		foreach(qint16 value, vectorQint8_) {
+			targetVector.append((double)value);
+		}
+		break;
+	case AMDSDataTypeDefinitions::Unsigned16:
+		foreach(quint16 value, vectorQint8_) {
+			targetVector.append((double)value);
+		}
+		break;
+	case AMDSDataTypeDefinitions::Signed32:
+		foreach(qint32 value, vectorQint8_) {
+			targetVector.append((double)value);
+		}
+		break;
+	case AMDSDataTypeDefinitions::Unsigned32:
+		foreach(quint32 value, vectorQint8_) {
+			targetVector.append((double)value);
+		}
+		break;
+	case AMDSDataTypeDefinitions::Signed64:
+		foreach(qint64 value, vectorQint8_) {
+			targetVector.append((double)value);
+		}
+		break;
+	case AMDSDataTypeDefinitions::Unsigned64:
+		foreach(quint64 value, vectorQint8_) {
+			targetVector.append((double)value);
+		}
+		break;
+	case AMDSDataTypeDefinitions::Float:
+		foreach(float value, vectorQint8_) {
+			targetVector.append((double)value);
+		}
+		break;
+	case AMDSDataTypeDefinitions::Double:
+		targetVector = vectorDouble_;
+		break;
+	case AMDSDataTypeDefinitions::InvalidType:
+	default:
+		break;
+	}
+
+	return targetVector;
+}
+
 int AMDSFlatArray::size() const{
 	switch(dataType_){
 	case AMDSDataTypeDefinitions::Signed8:

--- a/source/DataElement/AMDSFlatArray.h
+++ b/source/DataElement/AMDSFlatArray.h
@@ -52,7 +52,7 @@ public:
 	inline const QVector<qint64>& constVectorQint64() const { return vectorQint64_; }
 	inline const QVector<quint64>& constVectorQuint64() const { return vectorQuint64_; }
 	inline const QVector<float>& constVectorFloat() const { return vectorFloat_; }
-	inline const QVector<double>& constVectorDouble() const { return vectorDouble_; }
+	const QVector<double> constVectorDouble() const;
 
 	/// returns the size of the DataArray
 	int size() const;

--- a/source/DataElement/AMDSFlatArray.h
+++ b/source/DataElement/AMDSFlatArray.h
@@ -52,7 +52,8 @@ public:
 	inline const QVector<qint64>& constVectorQint64() const { return vectorQint64_; }
 	inline const QVector<quint64>& constVectorQuint64() const { return vectorQuint64_; }
 	inline const QVector<float>& constVectorFloat() const { return vectorFloat_; }
-	const QVector<double> constVectorDouble() const;
+	inline const QVector<double>& constVectorDouble() const { return vectorDouble_; }
+	const QVector<double> asConstVectorDouble() const;
 
 	/// returns the size of the DataArray
 	int size() const;

--- a/source/Detector/Amptek/AmptekSDD123Detector.cpp
+++ b/source/Detector/Amptek/AmptekSDD123Detector.cpp
@@ -144,7 +144,9 @@ AMDSFlatArray *AmptekSDD123Detector::readSpectrumData(const QByteArray &spectrum
 		spectrum.append(tmpData.toHex().toInt(&ok, 16));
 
 //		spectrumArray->setValue(index, tmpData.toHex().toInt(&ok, 16));
-		spectrumArray->setValue(index, spectrum.last());
+
+//		spectrumArray->setValue(index, spectrum.last());
+		spectrumArray->setValue(index, (quint16)(spectrum.last()));
 	}
 
 	//qDebug() << "Spectrum ready:\n " << spectrum;

--- a/source/Detector/Amptek/SGM/AmptekSDD123EPICSDetectorManager.cpp
+++ b/source/Detector/Amptek/SGM/AmptekSDD123EPICSDetectorManager.cpp
@@ -268,7 +268,7 @@ void AmptekSDD123EPICSDetectorManager::dataHelper(AMDSDataHolder *spectrum, AMDS
 	spectrum->data(&spectrumData);
 
 	if (spectrumData.dataType() == AMDSDataTypeDefinitions::Double)
-		spectrumControl_->setValues(spectrumData.constVectorDouble());
+		spectrumControl_->setValues(spectrumData.asConstVectorDouble());
 	else
 		AMDSRunTimeSupport::debugMessage(AMDSRunTimeSupport::AlertMsg, this, AMDS_ALERT_INVALID_DATA_TYPE, QString("The dataType of the data array (%1) is NOT expected Double type.").arg(spectrumData.dataType()));
 

--- a/source/application/AMDSCentralServerSGMAmptek.cpp
+++ b/source/application/AMDSCentralServerSGMAmptek.cpp
@@ -56,17 +56,10 @@ void AMDSCentralServerSGMAmptek::initializeConfiguration()
 	// Commented out PV and IP details for actual beamline ampteks, so can test on some detectors without interfering with beamline operations
 //	configurationMaps_.append(new AmptekSDD123ConfigurationMap("Amptek SDD 239", "amptek:sdd1", QHostAddress("192.168.0.239"), QHostAddress("192.168.0.139"), 12004, QHostAddress("192.168.10.104"), AMDSDataTypeDefinitions::Unsigned16, 1024, this));
 
-	/* We want to do this, but we can't until the Acquaman side has support to generically get the data as QVector<double> independent of underlying type
 	amptekConfigurationMaps_.append(new AmptekSDD123ConfigurationMap("Amptek SDD 240", "amptek:sdd2", QHostAddress("192.168.0.240"), QHostAddress("192.168.0.140"), 12004, QHostAddress("192.168.10.104"), AMDSDataTypeDefinitions::Unsigned16, 1024, this));
 	amptekConfigurationMaps_.append(new AmptekSDD123ConfigurationMap("Amptek SDD 241", "amptek:sdd3", QHostAddress("192.168.0.241"), QHostAddress("192.168.0.141"), 12004, QHostAddress("192.168.10.104"), AMDSDataTypeDefinitions::Unsigned16, 1024, this));
 	amptekConfigurationMaps_.append(new AmptekSDD123ConfigurationMap("Amptek SDD 242", "amptek:sdd4", QHostAddress("192.168.0.242"), QHostAddress("192.168.0.142"), 12004, QHostAddress("192.168.10.104"), AMDSDataTypeDefinitions::Unsigned16, 1024, this));
 	amptekConfigurationMaps_.append(new AmptekSDD123ConfigurationMap("Amptek SDD 243", "amptek:sdd5", QHostAddress("192.168.0.243"), QHostAddress("192.168.0.143"), 12004, QHostAddress("192.168.10.104"), AMDSDataTypeDefinitions::Unsigned16, 1024, this));
-	*/
-
-	amptekConfigurationMaps_.append(new AmptekSDD123ConfigurationMap("Amptek SDD 240", "amptek:sdd2", QHostAddress("192.168.0.240"), QHostAddress("192.168.0.140"), 12004, QHostAddress("192.168.10.104"), AMDSDataTypeDefinitions::Double, 1024, this));
-	amptekConfigurationMaps_.append(new AmptekSDD123ConfigurationMap("Amptek SDD 241", "amptek:sdd3", QHostAddress("192.168.0.241"), QHostAddress("192.168.0.141"), 12004, QHostAddress("192.168.10.104"), AMDSDataTypeDefinitions::Double, 1024, this));
-	amptekConfigurationMaps_.append(new AmptekSDD123ConfigurationMap("Amptek SDD 242", "amptek:sdd4", QHostAddress("192.168.0.242"), QHostAddress("192.168.0.142"), 12004, QHostAddress("192.168.10.104"), AMDSDataTypeDefinitions::Double, 1024, this));
-	amptekConfigurationMaps_.append(new AmptekSDD123ConfigurationMap("Amptek SDD 243", "amptek:sdd5", QHostAddress("192.168.0.243"), QHostAddress("192.168.0.143"), 12004, QHostAddress("192.168.10.104"), AMDSDataTypeDefinitions::Double, 1024, this));
 }
 
 void AMDSCentralServerSGMAmptek::initializeBufferGroup()


### PR DESCRIPTION
If the underlayer type is not double, return a copy of the current data and make them double.

https://github.com/acquaman/acquaman/issues/1720
