### PR TITLE
PullRequest for Issue83: add final signals to indicate that the AMDSClientAppController ready for service or not

### DIFF
--- a/source/appController/AMDSClientAppController.cpp
+++ b/source/appController/AMDSClientAppController.cpp
@@ -105,12 +105,15 @@ void AMDSClientAppController::openNetworkSession()
 
 			networkSession_ = new QNetworkSession(config);
 			connect(networkSession_, SIGNAL(opened()), this, SLOT(onNetworkSessionOpened()));
+			connect(networkSession_, SIGNAL(closed()), this, SLOT(onNetworkSessionClosed()));
+			connect(networkSession_, SIGNAL(stateChanged(QNetworkSession::State)), this, SLOT(onNetworkSessionStateChanged(QNetworkSession::State)));
+			connect(networkSession_, SIGNAL(error(QNetworkSession::SessionError)), this, SLOT(onNetworkSessionError(QNetworkSession::SessionError)));
 
 			emit networkSessionOpening();
 			networkSession_->open();
 		}
 		else{
-			emit networkSessionOpened();
+			emit AMDSClientControllerReady();
 		}
 	}
 }
@@ -338,8 +341,36 @@ void AMDSClientAppController::onNetworkSessionOpened()
 	settings.setValue(QLatin1String("DefaultNetworkConfiguration"), id);
 	settings.endGroup();
 
-	emit networkSessionOpened();
+	emit AMDSClientControllerReady();
 }
+
+void AMDSClientAppController::onNetworkSessionClosed()
+{
+	emit AMDSClientControllerError("AMDSClientAppController: Network session is closed. Pls check the connection");
+}
+
+void AMDSClientAppController::onNetworkSessionStateChanged(QNetworkSession::State newState)
+{
+	switch(newState) {
+	case QNetworkSession::Connected:
+		emit AMDSClientControllerReady();
+		break;
+	case QNetworkSession::Disconnected:
+		emit AMDSClientControllerError("AMDSClientAppController: Network session is disconnected!");
+		break;
+	case QNetworkSession::NotAvailable:
+		emit AMDSClientControllerError("AMDSClientAppController: Network session is NOT available!");
+		break;
+	default:
+		break;
+	}
+}
+
+void AMDSClientAppController::onNetworkSessionError(QNetworkSession::SessionError errorCode)
+{
+	emit AMDSClientControllerError(QString("AMDSClientAppController: Network session failed with error code (%1)!").arg(errorCode));
+}
+
 
 AMDSClientTCPSocket * AMDSClientAppController::establishSocketConnection(const QString &hostName, quint16 portNumber)
 {

--- a/source/appController/AMDSClientAppController.cpp
+++ b/source/appController/AMDSClientAppController.cpp
@@ -118,7 +118,7 @@ void AMDSClientAppController::openNetworkSession()
 			networkSession_->open();
 		}
 		else{
-			emit AMDSClientControllerReady();
+			emit AMDSClientControllerConnected();
 		}
 	}
 }
@@ -386,22 +386,22 @@ void AMDSClientAppController::onNetworkSessionOpened()
 	settings.setValue(QLatin1String("DefaultNetworkConfiguration"), id);
 	settings.endGroup();
 
-	emit AMDSClientControllerReady();
+	emit AMDSClientControllerConnected();
 }
 
 void AMDSClientAppController::onNetworkSessionClosed()
 {
-	emit AMDSClientControllerError("AMDSClientAppController: Network session is closed. Pls check the connection");
+	emit AMDSClientControllerNetworkSessionClosed("AMDSClientAppController: Network session is closed. Pls check the connection");
 }
 
 void AMDSClientAppController::onNetworkSessionStateChanged(QNetworkSession::State newState)
 {
 	switch(newState) {
 	case QNetworkSession::Connected:
-		emit AMDSClientControllerReady();
+		emit AMDSClientControllerConnected();
 		break;
 	case QNetworkSession::Disconnected:
-		emit AMDSClientControllerError("AMDSClientAppController: Network session is disconnected!");
+		emit AMDSClientControllerDisconnected();
 		break;
 	case QNetworkSession::NotAvailable:
 		emit AMDSClientControllerError("AMDSClientAppController: Network session is NOT available!");

--- a/source/appController/AMDSClientAppController.h
+++ b/source/appController/AMDSClientAppController.h
@@ -5,8 +5,7 @@
 #include <QHash>
 #include <QDateTime>
 #include <QTcpSocket>
-
-class QNetworkSession;
+#include <QNetworkSession>
 
 class AMDSServer;
 class AMDSClientTCPSocket;
@@ -18,6 +17,9 @@ class AMDSClientRequest;
 
 #define AMDS_CLIENT_INFO_HAND_SHAKE_MESSAGE 10100
 #define AMDS_CLIENT_INFO_NETWORK_SESSION_STARTED 10101
+#define AMDS_CLIENT_ERR_NETWORK_SESSION_CLOSED 10102
+#define AMDS_CLIENT_ERR_NETWORK_SESSION_INVALID_STATE 10103
+#define AMDS_CLIENT_ERR_NETWORK_SESSION_ERROR 10104
 
 #define AMDS_CLIENT_ERR_INVALID_MESSAGE_TYPE 10200
 
@@ -73,13 +75,16 @@ public:
 signals:
 	/// signal to indicate that the manager object is opening a network session
 	void networkSessionOpening();
-	/// signal to indicate that a network session is opened
-	void networkSessionOpened();
+
+	/// signal to indicate that the AMDS Client App Controller is ready for service
+	void AMDSClientControllerReady();
+	/// signal to indicate that the AMDS Client App Controller is in invalid state
+	void AMDSClientControllerError(const QString &errorMsg);
+	/// signal to indicate that there are server errors
+	void serverError(int errorCode, bool disconnectServer, const QString &hostIdentifier, const QString &errorMessage);
 
 	/// signal to indicate that a new server is connected
 	void newServerConnected(const QString &hostIdentifier);
-	/// signal to indicate that there are server errors
-	void serverError(int errorCode, bool disconnectServer, const QString &hostIdentifier, const QString &errorMessage);
 	/// signal to indicate that the data is sent from server for read
 	void requestDataReady(AMDSClientRequest*);
 
@@ -97,6 +102,12 @@ protected:
 private slots:
 	/// slot to handle the signal of network session opened
 	void onNetworkSessionOpened();
+	/// slot to handle the signal of network session closed
+	void onNetworkSessionClosed();
+	/// slot to handle the signal of network session state changed
+	void onNetworkSessionStateChanged(QNetworkSession::State);
+	/// slot to handle the signal of network session error
+	void onNetworkSessionError(QNetworkSession::SessionError);
 
 private:
 	/// establish TCP socket connection to a specific hostName and the portNumber

--- a/source/appController/AMDSClientAppController.h
+++ b/source/appController/AMDSClientAppController.h
@@ -88,7 +88,11 @@ signals:
 	void networkSessionOpening();
 
 	/// signal to indicate that the AMDS Client App Controller is ready for service
-	void AMDSClientControllerReady();
+	void AMDSClientControllerConnected();
+	/// signal to indicate that the AMDS Client App Controller is disconnected
+	void AMDSClientControllerDisconnected();
+	/// signal to indicate that the AMDS Client App Controller network session is closed
+	void AMDSClientControllerNetworkSessionClosed(const QString &errorMsg);
 	/// signal to indicate that the AMDS Client App Controller is in invalid state
 	void AMDSClientControllerError(const QString &errorMsg);
 	/// signal to indicate that there are server errors


### PR DESCRIPTION
As NetworkSessionOpenning() and NetworkSessionOpenned() are not always emitted, the client might not know when to start request service from AMDS. Two new signals are added: AMDSClientControllerReady() and AMDSClientControllerError(), to indicate that the AMDSClietAppController is ready for service or not.
#83
