### PR TITLE
Pull Request for Issue1696 Acquaman: AMDS Trigger/Dwell Interface

### DIFF
--- a/source/DataElement/AMDSBufferGroup.cpp
+++ b/source/DataElement/AMDSBufferGroup.cpp
@@ -173,6 +173,7 @@ void AMDSBufferGroup::processClientRequest(AMDSClientRequest *clientRequest, boo
 		break;
 	}
 
+	// Handle the trigger/dwell flattening request differently than usual requests
 	if(internalRequest)
 		emit internalRequestProcessed(clientRequest);
 	else

--- a/source/DataElement/AMDSBufferGroup.cpp
+++ b/source/DataElement/AMDSBufferGroup.cpp
@@ -119,7 +119,6 @@ void AMDSBufferGroup::finishDwellDataUpdate(double elapsedTime)
 	}
 }
 
-#include <QDebug>
 void AMDSBufferGroup::processClientRequest(AMDSClientRequest *clientRequest, bool internalRequest){
 	QReadLocker readLock(&lock_);
 
@@ -150,8 +149,6 @@ void AMDSBufferGroup::processClientRequest(AMDSClientRequest *clientRequest, boo
 	}
 	case AMDSClientRequestDefinitions::StartTimeToEndTime:{
 		AMDSClientStartTimeToEndTimeDataRequest *clientStartTimeToEndTimeDataRequest = qobject_cast<AMDSClientStartTimeToEndTimeDataRequest*>(clientRequest);
-		qDebug() << "Handling a StartTimeToEndTime request with " << clientStartTimeToEndTimeDataRequest->startTime() << clientStartTimeToEndTimeDataRequest->endTime()
-			    << clientStartTimeToEndTimeDataRequest->bufferName();
 		if(clientStartTimeToEndTimeDataRequest) {
 			populateData(clientStartTimeToEndTimeDataRequest);
 		}
@@ -292,9 +289,6 @@ void AMDSBufferGroup::populateData(AMDSClientStartTimeToEndTimeDataRequest* clie
 
 	int startIndex = getDataIndexByDateTime(startTime);
 	int endIndex = getDataIndexByDateTime(endTime);
-
-	qDebug() << "StartIndex: " << startIndex;
-	qDebug() << "EndIndex: " << endIndex;
 
 	if(startIndex == -1) {
 		clientDataRequest->setErrorMessage(QString("Could not locate data for start time %1 (ReqType: 4)").arg(startTime.toString()));

--- a/source/DataElement/AMDSBufferGroup.h
+++ b/source/DataElement/AMDSBufferGroup.h
@@ -55,11 +55,13 @@ public:
 public slots:
 	/// Slot which handles a request for data. The buffer group will attempt to populate the request
 	/// based on the instructions it includes. When the data request is ready the dataRequestReady signal is emitted
-	void processClientRequest(AMDSClientRequest *clientRequest);
+	void processClientRequest(AMDSClientRequest *clientRequest, bool internalRequest = false);
 
 signals:
 	/// Signal which indicates that a request for data has been processed and is ready to be sent back to the client
 	void clientRequestProcessed(AMDSClientRequest *clientRequest);
+
+	void internalRequestProcessed(AMDSClientRequest *clientRequest);
 
 	/// signal to indicate that the new data added for conitunous monitor
 	void continuousDataUpdate(AMDSDataHolder *continuousDataHolder);

--- a/source/DataElement/AMDSBufferGroup.h
+++ b/source/DataElement/AMDSBufferGroup.h
@@ -61,6 +61,7 @@ signals:
 	/// Signal which indicates that a request for data has been processed and is ready to be sent back to the client
 	void clientRequestProcessed(AMDSClientRequest *clientRequest);
 
+	/// Handles clientRequests that have been requested internally and don't need to be routed out of the server (flattening request for trigger/dwell)
 	void internalRequestProcessed(AMDSClientRequest *clientRequest);
 
 	/// signal to indicate that the new data added for conitunous monitor

--- a/source/Detector/Scaler/AMDSScalerDetector.cpp
+++ b/source/Detector/Scaler/AMDSScalerDetector.cpp
@@ -1,6 +1,5 @@
 #include "AMDSScalerDetector.h"
 
-#include <QDebug>
 #include <QTimer>
 
 #include "beamline/AMPVControl.h"
@@ -45,8 +44,6 @@ AMDSScalerDetector::AMDSScalerDetector(AMDSScalerConfigurationMap *scalerConfigu
 
 	defaultDwellTime_ = 1; // default 1ms
 	dwellTime_ = 1;
-//	defaultScansInABuffer_ = 1000;
-//	scansInABuffer_ = 1000;
 	defaultScansInABuffer_ = 100;
 	scansInABuffer_ = 100;
 	defaultTotalNumberOfScans_ = 0;
@@ -255,8 +252,9 @@ void AMDSScalerDetector::onTriggerDwellInterfaceStartControlValueChanged(double 
 
 void AMDSScalerDetector::onTriggerDwellInterfaceDwellTimeControlValueChanged(double value)
 {
-	if(connected_)
-		qDebug() << "Heard the trigger/dwell dwell time go to " << value;
+	if(connected_){
+		// Do nothing right now
+	}
 }
 
 void AMDSScalerDetector::onTriggerDwellTimerTimeout()

--- a/source/Detector/Scaler/AMDSScalerDetector.h
+++ b/source/Detector/Scaler/AMDSScalerDetector.h
@@ -67,6 +67,8 @@ signals:
 	/// signal to indicate that we received new counts data
 	void newScalerScanDataReceived(const AMDSDataHolderList &scanCountsDataHolder);
 
+	void requestFlattenedData(double seconds);
+
 public slots:
 	/// slot to start dwelling
 	void onServerGoingToStartDwelling();
@@ -97,6 +99,11 @@ protected slots:
 	/// slot to fetch the channel data buffer from the scaler scan control
 	void onFetchScanBuffer();
 
+	/// Listen to changes on the trigger/dwell start PV
+	void onTriggerDwellInterfaceStartControlValueChanged(double value);
+	/// Listen to changes on the trigger/dwell dwell time PV
+	void onTriggerDwellInterfaceDwellTimeControlValueChanged(double value);
+
 protected:
 	/// helper function to initialize the PV controls of the scaler
 	void initializePVControls();
@@ -124,6 +131,15 @@ protected:
 
 	/// the pv control to access the channel scan array
 	AMWaveformBinningSinglePVControl *scanBufferControl_;
+
+	/// The start control for the new trigger/dwell interface
+	AMSinglePVControl *triggerDwellInterfaceStartControl_;
+	/// The dwell time control for the new trigger/dwell interface
+	AMSinglePVControl *triggerDwellInterfaceDwellTimeControl_;
+	/// The dwell status control for the new trigger/dwell interface
+	AMSinglePVControl *triggerDwellInterfaceDwellStateControl_;
+	/// The feedback controls for the channels of the new trigger/dwell interface
+	QMap<int, AMSinglePVControl*> triggerDwellInterfaceChannelFeedbackControls_;
 
 
 	/// the dwell time to read the scaler buffer (in ms, default 1ms)

--- a/source/Detector/Scaler/AMDSScalerDetector.h
+++ b/source/Detector/Scaler/AMDSScalerDetector.h
@@ -152,6 +152,9 @@ protected:
 	/// The feedback controls for the channels of the new trigger/dwell interface
 	QMap<int, AMSinglePVControl*> triggerDwellInterfaceChannelFeedbackControls_;
 
+	/// The enable controls for the channels of the new trigger/dwell interface
+	QMap<int, AMSinglePVControl*> triggerDwellInterfaceChannelEnableControls_;
+
 
 	/// the dwell time to read the scaler buffer (in ms, default 1ms)
 	int defaultDwellTime_;

--- a/source/Detector/Scaler/AMDSScalerDetector.h
+++ b/source/Detector/Scaler/AMDSScalerDetector.h
@@ -9,6 +9,8 @@
 #include "Detector/AMDSDwellDetector.h"
 #include "Detector/Scaler/AMDSScalerConfigurationMap.h"
 
+class QTimer;
+
 class AMControlSet;
 class AMSinglePVControl;
 class AMWaveformBinningSinglePVControl;
@@ -79,6 +81,9 @@ public slots:
 	/// slot to disable a given channel
 	void onDisableChannel(int channelId);
 
+	/// Called to set the flattened data once the request has been processed
+	void setFlattenedData(const QVector<double> &data);
+
 protected slots:
 	/// slot to handle the all PV connected signal
 	void onAllControlsConnected(bool connected);
@@ -103,6 +108,9 @@ protected slots:
 	void onTriggerDwellInterfaceStartControlValueChanged(double value);
 	/// Listen to changes on the trigger/dwell dwell time PV
 	void onTriggerDwellInterfaceDwellTimeControlValueChanged(double value);
+
+	/// Called to actually request the flattened data from the server by emitting the signal
+	void onTriggerDwellTimerTimeout();
 
 protected:
 	/// helper function to initialize the PV controls of the scaler
@@ -138,6 +146,9 @@ protected:
 	AMSinglePVControl *triggerDwellInterfaceDwellTimeControl_;
 	/// The dwell status control for the new trigger/dwell interface
 	AMSinglePVControl *triggerDwellInterfaceDwellStateControl_;
+	/// The dwell mode control for the new trigger/dwell interface
+	AMSinglePVControl *triggerDwellInterfaceDwellModeControl_;
+
 	/// The feedback controls for the channels of the new trigger/dwell interface
 	QMap<int, AMSinglePVControl*> triggerDwellInterfaceChannelFeedbackControls_;
 
@@ -151,6 +162,9 @@ protected:
 	/// the total number of scans (default 0)
 	int defaultTotalNumberOfScans_;
 	int totalNumberOfScans_;
+
+	/// Timer in control of emitting signal to request flattened data
+	QTimer *triggerDwellTimer_;
 };
 
 #endif // AMDSSCALERDETECTOR_H

--- a/source/Detector/Scaler/AMDSScalerDetector.h
+++ b/source/Detector/Scaler/AMDSScalerDetector.h
@@ -69,6 +69,7 @@ signals:
 	/// signal to indicate that we received new counts data
 	void newScalerScanDataReceived(const AMDSDataHolderList &scanCountsDataHolder);
 
+	/// Signal to request flattened data from the central server
 	void requestFlattenedData(double seconds);
 
 public slots:

--- a/source/application/AMDSCentralServerSGMScaler.cpp
+++ b/source/application/AMDSCentralServerSGMScaler.cpp
@@ -50,10 +50,8 @@ void AMDSCentralServerSGMScaler::initializeBufferGroup()
 	// initialize bufferGroup for scaler
 	QList<AMDSAxisInfo> scalerBufferGroupAxes;
 	scalerBufferGroupAxes << AMDSAxisInfo("Channel", scalerConfigurationMap_->enabledChannels().count(), "Channel Axis", "");
-//	AMDSBufferGroupInfo scalerBufferGroupInfo(scalerConfigurationMap_->scalerName(), scalerConfigurationMap_->scalerName(), "Counts", scalerConfigurationMap_->dataType(), AMDSBufferGroupInfo::NoFlatten, scalerBufferGroupAxes);
 	AMDSBufferGroupInfo scalerBufferGroupInfo(scalerConfigurationMap_->scalerName(), scalerConfigurationMap_->scalerName(), "Counts", scalerConfigurationMap_->dataType(), AMDSBufferGroupInfo::Summary, scalerBufferGroupAxes);
 
-//	AMDSThreadedBufferGroup *scalerThreadedBufferGroup = new AMDSThreadedBufferGroup(scalerBufferGroupInfo, maxBufferSize_, false);
 	AMDSThreadedBufferGroup *scalerThreadedBufferGroup = new AMDSThreadedBufferGroup(scalerBufferGroupInfo, maxBufferSize_, true);
 	connect(scalerThreadedBufferGroup->bufferGroup(), SIGNAL(clientRequestProcessed(AMDSClientRequest*)), tcpDataServer_->server(), SLOT(onClientRequestProcessed(AMDSClientRequest*)));
 

--- a/source/application/AMDSCentralServerSGMScaler.h
+++ b/source/application/AMDSCentralServerSGMScaler.h
@@ -36,6 +36,9 @@ protected slots:
 	/// slot to handle new scaler data request to add the data to buffergroup
 	void onNewScalerScanDataReceivedd(const AMDSDataHolderList &scalerScanCountsDataHolder);
 
+	void onScalerDetectorRequestFlattenedData(double seconds);
+	void onInternalRequestProcessed(AMDSClientRequest *clientRequest);
+
 protected:
 	/// function to initialize the system configurations
 	void initializeConfiguration();

--- a/source/application/AMDSCentralServerSGMScaler.h
+++ b/source/application/AMDSCentralServerSGMScaler.h
@@ -36,7 +36,9 @@ protected slots:
 	/// slot to handle new scaler data request to add the data to buffergroup
 	void onNewScalerScanDataReceivedd(const AMDSDataHolderList &scalerScanCountsDataHolder);
 
+	/// Called when the scaler requests flattened data. Sets the latches for internalRequestActive_ and dwellSecondsRequested
 	void onScalerDetectorRequestFlattenedData(double seconds);
+	/// Handles the internal requests that are processed and send data back to detector
 	void onInternalRequestProcessed(AMDSClientRequest *clientRequest);
 
 protected:
@@ -61,6 +63,11 @@ protected:
 	AMDSScalerDetectorManager *scalerDetectorManager_;
 	/// the scaler server manager
 	AMDSDetectorServerManager *scalerDetectorServerManager_;
+
+	/// Latches that we have an internal request in processing and handles it differently
+	bool internalRequestActive_;
+	/// Latches the flattening time in seconds
+	double dwellSecondsRequested_;
 };
 
 #endif // AMDSCENTRALSERVERSGM_H


### PR DESCRIPTION
I've implemented the guts of the trigger/dwell interface on the scaler as well as the softIOC db needed to run with it. 

This is related to the Issue1696 branch in acquaman itself. Between the two, there's a working implementation for trigger/dwell scaler on the AMDS Server side; a working CLSAMDSScaler class with associated classes; a working view class for the CLSAMDSScaler; and, a new CLSAMDSScalerChannelDetector. With all of these together I've run a bunch of step scans using the Commissioning Tool on energy against the scaler channels and the ampteks.

Although this work basically stands by itself, I would mind if @iainworkman would chat with me about how he likes to include the db files ... as I haven't done that yet.
