### PR TITLE
Pull Request for Issue92: Amptek AMDS Testing 

### DIFF
--- a/compositCommon/AcquamanMPlot.pri
+++ b/compositCommon/AcquamanMPlot.pri
@@ -1,15 +1,25 @@
 
 
 macx {
-		# EPICS Dependencies:
-		EPICS_INCLUDE_DIRS = $$PATH_TO_ACQUAMAN/../contrib/epics/base/include \
-								$$PATH_TO_ACQUAMAN/../contrib/epics/base/include/os/Darwin
-		EPICS_LIB_DIR = $$PATH_TO_ACQUAMAN/../contrib/epics/base/lib/darwin-x86
+		USERNAME = $$system(whoami)
 
-		QMAKE_CXXFLAGS_X86_64 *= "-mmacosx-version-min=10.7"
+		contains(USERNAME, chevrid){
 
-		QMAKE_LFLAGS_DEBUG *= "-mmacosx-version-min=10.7"
-		QMAKE_LFLAGS_RELEASE *= "-mmacosx-version-min=10.7"
+			# EPICS Dependencies:
+			EPICS_INCLUDE_DIRS = $$PATH_TO_ACQUAMAN/../contrib/epics/base/include \
+									$$PATH_TO_ACQUAMAN/../contrib/epics/base/include/os/Darwin
+			EPICS_LIB_DIR = $$PATH_TO_ACQUAMAN/../contrib/epics/base/lib/darwin-x86
+
+			QMAKE_CXXFLAGS_X86_64 *= "-mmacosx-version-min=10.7"
+
+			QMAKE_LFLAGS_DEBUG *= "-mmacosx-version-min=10.7"
+			QMAKE_LFLAGS_RELEASE *= "-mmacosx-version-min=10.7"
+		} else {
+			# EPICS Dependencies:
+			EPICS_INCLUDE_DIRS = $$PROJECT_ROOT/acquaman/contrib/epics/base/include \
+						$$PROJECT_ROOT/acquaman/contrib/epics/base/include/os/Darwin
+			EPICS_LIB_DIR = $$PROJECT_ROOT/acquaman/contrib/epics/base/lib/darwin-x86
+		}
 } else {
 # EPICS Dependencies:
 	EPICS_INCLUDE_DIRS = /home/epics/src/R3.14.12/base/include \

--- a/compositCommon/AcquamanMPlot.pri
+++ b/compositCommon/AcquamanMPlot.pri
@@ -2,9 +2,14 @@
 
 macx {
 		# EPICS Dependencies:
-		EPICS_INCLUDE_DIRS = $$PROJECT_ROOT/acquaman/contrib/epics/base/include \
-					$$PROJECT_ROOT/acquaman/contrib/epics/base/include/os/Darwin
-		EPICS_LIB_DIR = $$PROJECT_ROOT/acquaman/contrib/epics/base/lib/darwin-x86
+		EPICS_INCLUDE_DIRS = $$PATH_TO_ACQUAMAN/../contrib/epics/base/include \
+								$$PATH_TO_ACQUAMAN/../contrib/epics/base/include/os/Darwin
+		EPICS_LIB_DIR = $$PATH_TO_ACQUAMAN/../contrib/epics/base/lib/darwin-x86
+
+		QMAKE_CXXFLAGS_X86_64 *= "-mmacosx-version-min=10.7"
+
+		QMAKE_LFLAGS_DEBUG *= "-mmacosx-version-min=10.7"
+		QMAKE_LFLAGS_RELEASE *= "-mmacosx-version-min=10.7"
 } else {
 # EPICS Dependencies:
 	EPICS_INCLUDE_DIRS = /home/epics/src/R3.14.12/base/include \

--- a/source/DataElement/AMDSFlatArray.cpp
+++ b/source/DataElement/AMDSFlatArray.cpp
@@ -718,6 +718,9 @@ bool AMDSFlatArray::resetTargetArrayAndReplaceData(AMDSFlatArray *targetArray) c
 }
 
 void AMDSFlatArray::resizeType(AMDSDataTypeDefinitions::DataType dataType, quint32 size){
+	if( (dataType_ == dataType) && (size == this->size()) )
+		return;
+
 	dataType_ = dataType;
 
 	switch(dataType_){

--- a/source/DataElement/AMDSFlatArray.cpp
+++ b/source/DataElement/AMDSFlatArray.cpp
@@ -725,34 +725,34 @@ void AMDSFlatArray::resizeType(AMDSDataTypeDefinitions::DataType dataType, quint
 
 	switch(dataType_){
 	case AMDSDataTypeDefinitions::Signed8:
-		vectorQint8_.resize(size);
+		vectorQint8_ = QVector<qint8>(size);
 		break;
 	case AMDSDataTypeDefinitions::Unsigned8:
-		vectorQuint8_.resize(size);
+		vectorQuint8_ = QVector<quint8>(size);
 		break;
 	case AMDSDataTypeDefinitions::Signed16:
-		vectorQint16_.resize(size);
+		vectorQint16_ = QVector<qint16>(size);
 		break;
 	case AMDSDataTypeDefinitions::Unsigned16:
-		vectorQuint16_.resize(size);
+		vectorQuint16_ = QVector<quint16>(size);
 		break;
 	case AMDSDataTypeDefinitions::Signed32:
-		vectorQint32_.resize(size);
+		vectorQint32_ = QVector<qint32>(size);
 		break;
 	case AMDSDataTypeDefinitions::Unsigned32:
-		vectorQuint32_.resize(size);
+		vectorQuint32_ = QVector<quint32>(size);
 		break;
 	case AMDSDataTypeDefinitions::Signed64:
-		vectorQint64_.resize(size);
+		vectorQint64_ = QVector<qint64>(size);
 		break;
 	case AMDSDataTypeDefinitions::Unsigned64:
-		vectorQuint64_.resize(size);
+		vectorQuint64_ = QVector<quint64>(size);
 		break;
 	case AMDSDataTypeDefinitions::Float:
-		vectorFloat_.resize(size);
+		vectorFloat_ = QVector<float>(size);
 		break;
 	case AMDSDataTypeDefinitions::Double:
-		vectorDouble_.resize(size);
+		vectorDouble_ = QVector<double>(size);
 		break;
 	case AMDSDataTypeDefinitions::InvalidType:
 		break;

--- a/source/Detector/Amptek/AmptekEventDefinitions.h
+++ b/source/Detector/Amptek/AmptekEventDefinitions.h
@@ -29,7 +29,7 @@ public:
 	AmptekSpectrumEvent() : QEvent( (QEvent::Type)AmptekEventDefinitions::SpectrumEvent) {}
 
 	QString detectorSourceName_;
-	AMDSFlatArray spectrum_;
+	AMDSFlatArray *spectrum_;
 	AMDSDwellStatusData statusData_;
 };
 

--- a/source/Detector/Amptek/AmptekSDD123Detector.cpp
+++ b/source/Detector/Amptek/AmptekSDD123Detector.cpp
@@ -104,7 +104,7 @@ void AmptekSDD123Detector::onSpectrumPacketEventReceived(AmptekSpectrumPacketEve
 
 		AmptekSpectrumEvent *spectrumEvent = new AmptekSpectrumEvent();
 		spectrumEvent->detectorSourceName_ = name();
-		spectrumEvent->spectrum_ = *spectrumArray;
+		spectrumEvent->spectrum_ = spectrumArray;
 		spectrumEvent->statusData_ = statusData;
 
 		QCoreApplication::postEvent(spectrumReceiver_, spectrumEvent);

--- a/source/Detector/Amptek/AmptekSDD123DetectorManager.cpp
+++ b/source/Detector/Amptek/AmptekSDD123DetectorManager.cpp
@@ -211,7 +211,7 @@ void AmptekSDD123DetectorManager::setDetectorFastPeakingTime(AmptekSDD123Detecto
 }
 
 void AmptekSDD123DetectorManager::onSpectrumEventReceived(AmptekSpectrumEvent *spectrumEvent){
-	AMDSFlatArray spectrumData = spectrumEvent->spectrum_;
+	AMDSFlatArray *spectrumData = spectrumEvent->spectrum_;
 	AMDSDwellStatusData statusData = spectrumEvent->statusData_;
 
 	if(setPresetDwellEndTimeOnNextEvent_){
@@ -236,8 +236,10 @@ void AmptekSDD123DetectorManager::onSpectrumEventReceived(AmptekSpectrumEvent *s
 
 	// generate the spectrum data holder and notice the bufferGroup new data is ready
 	AMDSDwellSpectralDataHolder *oneHistogram = new AMDSDwellSpectralDataHolder(detector_->dataType(), detector_->bufferSize(), this);
-	oneHistogram->setData(&spectrumData);
+	oneHistogram->setData(spectrumData);
 	oneHistogram->setDwellStatusData(statusData);
+
+	delete spectrumData;
 
 	emit newHistrogramReceived(detectorName(), oneHistogram);
 

--- a/source/Detector/Amptek/AmptekSDD123Server.h
+++ b/source/Detector/Amptek/AmptekSDD123Server.h
@@ -152,6 +152,10 @@ protected:
 	QByteArray totalResponseDatagram_;
 	/// the size of the total response datagram
 	int totalResponseDatagramSize_;
+	/// the number of bytes we've read so far for this response
+	int currentlyReadSize_;
+	/// the byte pattern that signifies the amptek packet header
+	QByteArray amptekHeaderBytes_;
 	/// flag to indicate whether the total response datagram is still on the way (more packets are expecting)
 	bool stillReceivingResponseDatagram_;
 //	/// flag to indicate that the response packet is ready

--- a/source/Detector/Amptek/SGM/AmptekCommandManagerSGM.cpp
+++ b/source/Detector/Amptek/SGM/AmptekCommandManagerSGM.cpp
@@ -128,6 +128,13 @@ void AmptekCommandManagerSGM::initiateAMDSCommands()
 	commands_.append( AMDSCommand(ResponseConfiguration,                 "8207", "Configuration Readback"));
 	commands_.append( AMDSCommand(ResponseCommTestEchoPacket,            "8f7f", "Comm test - Echo packet Response"));
 
+	// We have to add the acknowledge and repsonse commands to the list before we do the request. The internalCreateResponsesFromText depends on these.
+	int acknowledgeAndResponseCommands = commands_.count();
+	for (int i = 0; i < acknowledgeAndResponseCommands; i++) {
+		commandHash_[commands_.at(i).commandId()] = commands_.at(i);
+		commandHexMapping_.set(commands_.at(i).command(), commands_.at(i));
+	}
+
 	//Request types
 	QStringList tempResponses = QStringList() << "Request Status Packet Response" << "NormalErrors";
 	commands_.append( AMDSCommand(ReqeustStatusPacket, "0101", "Request Status Packet", 7, 3, internalCreateResponsesFromText(tempResponses)));
@@ -177,8 +184,8 @@ void AmptekCommandManagerSGM::initiateAMDSCommands()
 	tempResponses = QStringList() << "Comm test - Echo packet Response" << "NormalErrors";
 	commands_.append( AMDSCommand(RequestCommTestEchoPacket, "f17f", "Comm test - Echo packet", 7, 1, internalCreateResponsesFromText(tempResponses)));
 
-
-	for (int i = 0; i < commands_.count(); i++) {
+	// Start iterating from the end of the acknowledge/response set
+	for (int i = acknowledgeAndResponseCommands; i < commands_.count(); i++) {
 		commandHash_[commands_.at(i).commandId()] = commands_.at(i);
 		commandHexMapping_.set(commands_.at(i).command(), commands_.at(i));
 	}


### PR DESCRIPTION
Fixed a series of memory issues in AMDS-Amptek.
- A chain of ownership between AmptekSpectrumEvent, AmptekSDD123Detector, and AmptekSDD123DetectorManager led to an AMDSFlatArray being new'd and then, eventually, iteratively copied without the original being deleted. Fixed this issue by changing some members to natural pointer types and deleting after no longer needed.
- Fixed two issues in AMDSFlatArray::resizeType. First was a lack of protection that caused the function to execute even when the dateType and size remained the same. Second was using resize instead of allocating new vector
- Fixed an issue with QByteArray appends in the udpSocket for AmptekSDD123Server. This is like the one in AMDSClientTCPSocket
- Finally, fixed a major bug that caused request types to have no valid response or acknowledge types. This meant the unbound growth of the unrequestedPackets_ in AmptekSDD123Server.
