### PR TITLE
Pull Request for Issue119: Fix a memory isssue.

### DIFF
--- a/source/DataElement/AMDSBuffer.h
+++ b/source/DataElement/AMDSBuffer.h
@@ -17,7 +17,7 @@ class AMDSBuffer
 public:
 	/// Creates a AMDSBuffer to store maxSize number of elements
 	AMDSBuffer(int maxSize) :
-		elements_(maxSize),
+		elements_(maxSize, 0),
 		maxSize_(maxSize),
 		nextPosition_(0),
 		totalElementsAdded_(0)
@@ -74,6 +74,7 @@ public:
 		QWriteLocker writeLock(&lock);
 		totalElementsAdded_ = 0;
 		nextPosition_ = 0;
+		elements_.clear();
 	}
 
 	/// The number of items currently stored in the AMDSBuffer.
@@ -121,7 +122,7 @@ class AMDSBuffer<T*>
 public:
 	/// Creates a AMDSBuffer to store maxSize number of elements
 	AMDSBuffer(int maxSize) :
-		elements_(maxSize),
+		elements_(maxSize, 0),
 		maxSize_(maxSize),
 		nextPosition_(0),
 		totalElementsAdded_(0)
@@ -155,7 +156,13 @@ public:
 	const T* at(int index) const
 	{
 		QReadLocker readLock(&lock);
-		return (*this)[index];
+		return (*this)[convertIndex(index)];
+	}
+
+	void setElementNull(int index) {
+		QWriteLocker writeLock(&lock);
+
+		elements_[convertIndex(index)] = 0;
 	}
 
 	/// The maximum number of elements to be stored in the AMDSBuffer. Once this limit is reached
@@ -183,8 +190,10 @@ public:
 	/// Removes all items from the AMDSBuffer and, if it owns them, frees their memory
 	void clear() {
 		QWriteLocker writeLock(&lock);
+
 		totalElementsAdded_ = 0;
 		nextPosition_ = 0;
+		elements_.clear();
 	}
 
 	/// The number of items currently stored in the AMDSBuffer.

--- a/source/DataElement/AMDSBufferGroup.cpp
+++ b/source/DataElement/AMDSBufferGroup.cpp
@@ -52,6 +52,7 @@ void AMDSBufferGroup::clear()
 
 	for(int iElement = 0, elementCount = dataHolders_.count(); iElement < elementCount; iElement++) {
 		dataHolders_[iElement]->deleteLater();
+		dataHolders_.setElementNull(iElement);
 	}
 	dataHolders_.clear();
 
@@ -114,7 +115,8 @@ void AMDSBufferGroup::finishDwellDataUpdate(double elapsedTime)
 			emit dwellFinishedStatusDataUpdate(cumulativeStatusData, count());
 			emit dwellFinishedAllDataUpdate(specturalCumulativeDataHolder, cumulativeStatusData, count(), elapsedTime);
 		} else {
-			AMDSRunTimeSupport::debugMessage(AMDSRunTimeSupport::AlertMsg, this, AMDS_ALERT_DATA_HOLDER_TYPE_NOT_SUPPORT, QString("The cumulative dataHolder type (%1) is NOT supported at this moment.").arg(cumulativeDataHolder()->metaObject()->className()));
+			if (cumulativeDataHolder())
+				AMDSRunTimeSupport::debugMessage(AMDSRunTimeSupport::AlertMsg, this, AMDS_ALERT_DATA_HOLDER_TYPE_NOT_SUPPORT, QString("The cumulative dataHolder type (%1) is NOT supported at this moment.").arg(cumulativeDataHolder()->metaObject()->className()));
 		}
 	}
 }

--- a/source/DataElement/AMDSCommandManager.cpp
+++ b/source/DataElement/AMDSCommandManager.cpp
@@ -4,7 +4,7 @@ AMDSCommandManager::~AMDSCommandManager()
 {
 	commands_.clear();
 	commandHash_.clear();
-	commandHexMapping_.clear();
+//	commandHexMapping_.clear();
 }
 
 AMDSCommand AMDSCommandManager::amdsCommand(int commandID) const {

--- a/source/DataElement/AMDSEventData.cpp
+++ b/source/DataElement/AMDSEventData.cpp
@@ -119,7 +119,7 @@ void AMDSFullEventData::cloneData(AMDSEventData *sourceEventData)
 		AMDSEventData *newEventData = AMDSEventDataSupport::instantiateEventDataFromInstance(sourceFullEventData->lightWeightEventData());
 		lightWeightEventData_ = qobject_cast<AMDSLightWeightEventData *>(newEventData);
 		if (lightWeightEventData_)
-			(*lightWeightEventData_) = (*sourceFullEventData->lightWeightEventData());
+			lightWeightEventData_->cloneData(sourceFullEventData->lightWeightEventData());
 
 		setEventType(sourceFullEventData->eventType());
 		setTimeScale(sourceFullEventData->timeScale());

--- a/source/DataHolder/AMDSDataHolder.cpp
+++ b/source/DataHolder/AMDSDataHolder.cpp
@@ -101,7 +101,8 @@ void AMDSLightWeightDataHolder::cloneData(AMDSDataHolder *sourceDataHolder)
 			eventData_->deleteLater();
 
 		eventData_ = AMDSEventDataSupport::instantiateEventDataFromInstance(sourceLightWeightDataHolder->eventData());
-		(*eventData_) = *(sourceLightWeightDataHolder->eventData()); // copy the values of the eventData over
+		if (eventData_)
+			eventData_->cloneData(sourceLightWeightDataHolder->eventData()); // copy the values of the eventData over
 	}
 }
 

--- a/source/DataHolder/AMDSGenericFlatArrayDataHolder.cpp
+++ b/source/DataHolder/AMDSGenericFlatArrayDataHolder.cpp
@@ -53,7 +53,8 @@ void AMDSLightWeightGenericFlatArrayDataHolder::cloneData(AMDSDataHolder *source
 	AMDSLightWeightDataHolder::cloneData(sourceDataHolder);
 
 	AMDSLightWeightGenericFlatArrayDataHolder *sourceLightWeightGenericFlatArrayDataHolder = qobject_cast<AMDSLightWeightGenericFlatArrayDataHolder *>(sourceDataHolder);
-	sourceLightWeightGenericFlatArrayDataHolder->dataArray().resetTargetArrayAndReplaceData(&valueFlatArray_);
+	if (sourceLightWeightGenericFlatArrayDataHolder)
+		sourceLightWeightGenericFlatArrayDataHolder->dataArray().resetTargetArrayAndReplaceData(&valueFlatArray_);
 }
 
 bool AMDSLightWeightGenericFlatArrayDataHolder::writeToDataStream(QDataStream *dataStream)

--- a/source/Detector/Amptek/AmptekSDD123Server.cpp
+++ b/source/Detector/Amptek/AmptekSDD123Server.cpp
@@ -542,8 +542,6 @@ void AmptekSDD123Server::processResponseFeedback(const AmptekSDD123Packet &respo
 
 void AmptekSDD123Server::postSpectrumPlusStatusReadyResponse(const QByteArray &spectrumByteArray, const QByteArray &statusByteArray, int channelCount)
 {
-	replySpectrumTime_->restart();
-
 	emit spectrumDataReady(spectrumByteArray, channelCount);
 	emit statusDataReady(statusByteArray);
 
@@ -558,6 +556,8 @@ void AmptekSDD123Server::postSpectrumPlusStatusReadyResponse(const QByteArray &s
 	} else {
 		AMDSRunTimeSupport::debugMessage(AMDSRunTimeSupport::AlertMsg, this, AMPTEK_SERVER_ALERT_SPECTRUM_EVENT_RECEIVER_UNDEFINED, QString("No spectrum packet receiver"));
 	}
+
+	replySpectrumTime_->restart();
 }
 
 void AmptekSDD123Server::postConfigurationReadbackResponse(const QString &ASCIICommands)


### PR DESCRIPTION
When dwell is enabled, we will add the dataholder to the dwellBufferManager as well, which should be a new instance of AMDSDwellSpectrualDataHolder instead of the instance of existing ones. Otherwise, that dataholder might be released by one of the two bufferGroupManager and the app will crash if the other one wants to release it.
## 

@davidChevrier @dretrex this is the first bunch of changes based on my found last night.
