### PR TITLE
PullRequest for Issue119: A quick fix for the AMDS amptek crash 

### DIFF
--- a/source/DataElement/AMDSCommandManager.cpp
+++ b/source/DataElement/AMDSCommandManager.cpp
@@ -4,7 +4,7 @@ AMDSCommandManager::~AMDSCommandManager()
 {
 	commands_.clear();
 	commandHash_.clear();
-	commandHexMapping_.clear();
+//	commandHexMapping_.clear();
 }
 
 AMDSCommand AMDSCommandManager::amdsCommand(int commandID) const {

--- a/source/Detector/Amptek/AmptekSDD123DetectorManager.cpp
+++ b/source/Detector/Amptek/AmptekSDD123DetectorManager.cpp
@@ -239,8 +239,6 @@ void AmptekSDD123DetectorManager::onSpectrumEventReceived(AmptekSpectrumEvent *s
 	oneHistogram->setData(spectrumData);
 	oneHistogram->setDwellStatusData(statusData);
 
-	delete spectrumData;
-
 	emit newHistrogramReceived(detectorName(), oneHistogram);
 
 	if (dwellActive_) {
@@ -250,8 +248,13 @@ void AmptekSDD123DetectorManager::onSpectrumEventReceived(AmptekSpectrumEvent *s
 		if (presetDwellLocalStartTime_.isValid())
 			elapsedTime = ((double)presetDwellLocalStartTime_.msecsTo(presetDwellLocalEndTime_))/1000;
 
+		AMDSDwellSpectralDataHolder *dwellHistogram = new AMDSDwellSpectralDataHolder(detector_->dataType(), detector_->bufferSize(), this);
+		dwellHistogram->setData(spectrumData);
+		dwellHistogram->setDwellStatusData(statusData);
 		emit newDwellHistrogramReceived(detectorName(), oneHistogram, elapsedTime);
 	}
+
+	delete spectrumData;
 }
 
 void AmptekSDD123DetectorManager::onConfigurationValuesEventReceived(AmptekConfigurationValuesEvent *configurationValueEvent){

--- a/source/Detector/Amptek/AmptekSDD123DetectorManager.cpp
+++ b/source/Detector/Amptek/AmptekSDD123DetectorManager.cpp
@@ -251,7 +251,7 @@ void AmptekSDD123DetectorManager::onSpectrumEventReceived(AmptekSpectrumEvent *s
 		AMDSDwellSpectralDataHolder *dwellHistogram = new AMDSDwellSpectralDataHolder(detector_->dataType(), detector_->bufferSize(), this);
 		dwellHistogram->setData(spectrumData);
 		dwellHistogram->setDwellStatusData(statusData);
-		emit newDwellHistrogramReceived(detectorName(), oneHistogram, elapsedTime);
+		emit newDwellHistrogramReceived(detectorName(), dwellHistogram, elapsedTime);
 	}
 
 	delete spectrumData;


### PR DESCRIPTION
This is the quick fix for the AMDS Amptek crash, which is caused by the shared dataholder between the buffGroupManager and the dwellBufferGroupManager
