### PR TITLE
PullRequest for Issue123: refine the usage of QTimer with QThread

### DIFF
--- a/source/Connection/AMDSTCPDataServer.cpp
+++ b/source/Connection/AMDSTCPDataServer.cpp
@@ -32,16 +32,19 @@ AMDSTCPDataServer::AMDSTCPDataServer(QObject *parent) :
 	connect(hundredMillisecondStatsTimer_, SIGNAL(timeout()), this, SLOT(onHundredMillisecondStatsTimerTimeout()));
 	connect(oneSecondStatsTimer_, SIGNAL(timeout()), this, SLOT(onOneSecondStatsTimerTimeout()));
 	connect(tenSecondStatsTimer_, SIGNAL(timeout()), this, SLOT(onTenSecondStatsTimerTimeout()));
-
-	tenMillisecondStatsTimer_->start(10);
-	hundredMillisecondStatsTimer_->start(100);
-	oneSecondStatsTimer_->start(1000);
-	tenSecondStatsTimer_->start(10000);
 }
 
 AMDSTCPDataServer::~AMDSTCPDataServer()
 {
 	stop();
+}
+
+void AMDSTCPDataServer::onStartTimer()
+{
+	tenMillisecondStatsTimer_->start(10);
+	hundredMillisecondStatsTimer_->start(100);
+	oneSecondStatsTimer_->start(1000);
+	tenSecondStatsTimer_->start(10000);
 }
 
 void AMDSTCPDataServer::displayClients()

--- a/source/Connection/AMDSTCPDataServer.h
+++ b/source/Connection/AMDSTCPDataServer.h
@@ -51,6 +51,8 @@ signals:
 	void clientRequestRead(AMDSClientRequest*);
 
 public slots:
+	/// slot to start the timers
+	void onStartTimer();
 	/// Outputs to console a list of the currently connected clients' IP and ports. If no clients are connected
 	/// then displays "No clients connected"
 	void displayClients();

--- a/source/Connection/AMDSThreadedTCPDataServer.cpp
+++ b/source/Connection/AMDSThreadedTCPDataServer.cpp
@@ -14,6 +14,7 @@ AMDSThreadedTCPDataServer::AMDSThreadedTCPDataServer(QObject *parent) :
 	server_->moveToThread(thread_);
 
 	connect(thread_, SIGNAL(started()), this, SLOT(onThreadStarted()));
+	connect(thread_, SIGNAL(started()), server_, SLOT(onStartTimer()));
 	connect(thread_, SIGNAL(finished()), server_, SLOT(deleteLater()));
 
 	connect(this, SIGNAL(startServer(QString,quint16)), server_, SLOT(start(QString,quint16)));

--- a/source/DataElement/AMDSCommandManager.cpp
+++ b/source/DataElement/AMDSCommandManager.cpp
@@ -4,7 +4,7 @@ AMDSCommandManager::~AMDSCommandManager()
 {
 	commands_.clear();
 	commandHash_.clear();
-	commandHexMapping_.clear();
+//	commandHexMapping_.clear();
 }
 
 AMDSCommand AMDSCommandManager::amdsCommand(int commandID) const {

--- a/source/Detector/Amptek/AmptekSDD123ServerGroup.cpp
+++ b/source/Detector/Amptek/AmptekSDD123ServerGroup.cpp
@@ -12,6 +12,7 @@ AmptekSDD123ThreadedDataServerGroup::AmptekSDD123ThreadedDataServerGroup(QList<A
 	amptekServerGroup_ = new AmptekSDD123ServerGroup(configurationMaps);
 	amptekServerGroup_->moveToThread(amptekServerGroupThread_);
 
+	connect(amptekServerGroupThread_, SIGNAL(started()), amptekServerGroup_, SLOT(onStartTimer()));
 	connect(amptekServerGroupThread_, SIGNAL(finished()), amptekServerGroup_, SLOT(deleteLater()));
 
 	connect(amptekServerGroup_, SIGNAL(serverChangedToConfigurationState(int)), this, SIGNAL(serverChangedToConfigurationState(int)));
@@ -69,8 +70,6 @@ AmptekSDD123ServerGroup::AmptekSDD123ServerGroup(QList<AmptekSDD123Configuration
 	connect(serverAboutToConfigurationStateMapper_, SIGNAL(mapped(int)), this, SLOT(onServerAboutToChangeToConfigurationState(int)));
 	connect(serverConfigurationStateMapper_, SIGNAL(mapped(int)), this, SLOT(onServerChangedToConfigurationState(int)));
 	connect(serverDwellStateMapper_, SIGNAL(mapped(int)), this, SLOT(onServerChangedToDwellState(int)));
-
-	QTimer::singleShot(1000, this, SLOT(initiateAllRequestSpectrum()));
 }
 
 AmptekSDD123ServerGroup::~AmptekSDD123ServerGroup()
@@ -100,6 +99,11 @@ AmptekSDD123ServerGroup::~AmptekSDD123ServerGroup()
 AmptekSDD123Server* AmptekSDD123ServerGroup::serverAt(int index) const
 {
 	return servers_.at(index);
+}
+
+void AmptekSDD123ServerGroup::onStartTimer()
+{
+	QTimer::singleShot(1000, this, SLOT(initiateAllRequestSpectrum()));
 }
 
 void AmptekSDD123ServerGroup::setServerState(int index, AmptekSDD123ServerGroup::ServerState serverState){

--- a/source/Detector/Amptek/AmptekSDD123ServerGroup.h
+++ b/source/Detector/Amptek/AmptekSDD123ServerGroup.h
@@ -56,6 +56,8 @@ public:
 	AmptekSDD123Server* serverAt(int index) const;
 
 public slots:
+	/// slot to start the timer
+	void onStartTimer();
 	/// slot to set the state of one server
 	void setServerState(int index, AmptekSDD123ServerGroup::ServerState serverState);
 

--- a/source/application/AMDSCentralServer.cpp
+++ b/source/application/AMDSCentralServer.cpp
@@ -1,7 +1,6 @@
 #include "AMDSCentralServer.h"
 
 #include <QtCore/QCoreApplication>
-#include <QTimer>
 
 #include "appController/AMDSServerAppController.h"
 #include "Connection/AMDSThreadedTCPDataServer.h"

--- a/source/application/AMDSCentralServer.h
+++ b/source/application/AMDSCentralServer.h
@@ -4,8 +4,6 @@
 #include <QObject>
 #include <QMap>
 
-class QTimer;
-
 class AMDSThreadedBufferGroup;
 class AMDSThreadedTCPDataServer;
 class AMDSClientRequest;

--- a/source/application/SGM/AMDSCentralServerSGMAmptek.cpp
+++ b/source/application/SGM/AMDSCentralServerSGMAmptek.cpp
@@ -1,7 +1,5 @@
 #include "AMDSCentralServerSGMAmptek.h"
 
-#include <QTimer>
-
 #include "Connection/AMDSThreadedTCPDataServer.h"
 #include "ClientRequest/AMDSClientRequest.h"
 #include "ClientRequest/AMDSClientConfigurationRequest.h"

--- a/source/application/SGM/AMDSCentralServerSGMPV.cpp
+++ b/source/application/SGM/AMDSCentralServerSGMPV.cpp
@@ -1,6 +1,5 @@
 #include "AMDSCentralServerSGMPV.h"
 
-#include <QTimer>
 #include <QFile>
 
 #include "Connection/AMDSThreadedTCPDataServer.h"

--- a/source/application/SGM/AMDSCentralServerSGMScaler.cpp
+++ b/source/application/SGM/AMDSCentralServerSGMScaler.cpp
@@ -1,7 +1,5 @@
 #include "AMDSCentralServerSGMScaler.h"
 
-#include <QTimer>
-
 #include "Connection/AMDSThreadedTCPDataServer.h"
 #include "ClientRequest/AMDSClientRequest.h"
 #include "ClientRequest/AMDSClientConfigurationRequest.h"


### PR DESCRIPTION
Move the start() of QTimer to a slot, so that we can call it when the QThread is started
