### PR TITLE
Pull Request for Issue133: Amptek Dwell Times Only Accept Integer Values

### DIFF
--- a/source/Detector/Amptek/AmptekSDD123DetectorManager.cpp
+++ b/source/Detector/Amptek/AmptekSDD123DetectorManager.cpp
@@ -20,7 +20,7 @@ AmptekSDD123DetectorManager::AmptekSDD123DetectorManager(AmptekSDD123Configurati
 	detector_->setSpectrumReceiver(this);
 
 	dwellMode_ = AmptekSDD123DetectorManager::PresetDwell;
-	dwellTime_ = 2;
+	dwellTime_ = 2.0;
 
 	configurationRequestReason_ = AmptekSDD123DetectorManager::InvalidReason;
 
@@ -63,7 +63,7 @@ void AmptekSDD123DetectorManager::setRequestEventReceiver(QObject *requestEventR
 	requestEventReceiver_ = requestEventReceiver;
 }
 
-void AmptekSDD123DetectorManager::setDwellTime(int dwellTime){
+void AmptekSDD123DetectorManager::setDwellTime(double dwellTime){
 	dwellTime_ = dwellTime;
 }
 
@@ -210,7 +210,7 @@ void AmptekSDD123DetectorManager::onTriggerDwellTimerTimeout()
 bool AmptekSDD123DetectorManager::startTriggerDwellTimer()
 {
 	if(dwellTime_ > 0 && dwellTime_ < 100 && !triggerDwellTimer_->isActive()){
-		int asMSecs = dwellTime_*1000;
+		int asMSecs = int(dwellTime_*1000);
 		triggerDwellTimer_->setInterval(asMSecs);
 		triggerDwellTimer_->start();
 

--- a/source/Detector/Amptek/AmptekSDD123DetectorManager.h
+++ b/source/Detector/Amptek/AmptekSDD123DetectorManager.h
@@ -72,7 +72,7 @@ public slots:
 	void setRequestEventReceiver(QObject *requestEventReceiver);
 
 	/// function to set Dwell Time
-	void setDwellTime(int dwellTime);
+	void setDwellTime(double dwellTime);
 	/// function to set dwell mode
 	void setDwellMode(AmptekSDD123DetectorManager::DwellMode dwellMode);
 
@@ -141,7 +141,7 @@ protected:
 	/// flag to indicate whether the data is initialized or not (whether the coming package is the first package)
 	bool initialized_;
 	/// the default dwell time
-	int dwellTime_;
+	double dwellTime_;
 	/// the current dwell mode
 	AmptekSDD123DetectorManager::DwellMode dwellMode_;
 

--- a/source/Detector/Amptek/SGM/AmptekSDD123EPICSDetectorManager.cpp
+++ b/source/Detector/Amptek/SGM/AmptekSDD123EPICSDetectorManager.cpp
@@ -335,7 +335,7 @@ void AmptekSDD123EPICSDetectorManager::onClearSpectrumControlValueChange(double 
 
 void AmptekSDD123EPICSDetectorManager::onDwellTimeControlValueChange(double newValue){
 	if(!dwellTimeControl_->withinTolerance(dwellTime()))
-		setDwellTime((int)newValue);
+		setDwellTime(newValue);
 }
 
 void AmptekSDD123EPICSDetectorManager::onDwellModeControlValueChange(double newValue){


### PR DESCRIPTION
- AmptekSDD123DetectorManager::dwellTime_  changed to double
- Removed int cast of dwell time in AmptekSDD123EPICSDetectorManager
